### PR TITLE
docs: sync driver isolation and pluggable architecture changes

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,25 +1,41 @@
-# Ollama Module Refactoring - Complete Documentation Index
+# RUNE — Reliability Use-case Numeric Evaluator
+
+RUNE is an AI model benchmarking and provisioning platform that runs HolmesGPT
+against Kubernetes clusters, optionally provisioning GPU instances on Vast.ai.
+
+## Installation
+
+The core package (CLI + API server) has no HolmesGPT dependency:
+
+```bash
+pip install rune-bench                  # core only
+pip install rune-bench[holmes]          # + holmesgpt + supabase
+pip install rune-bench[all]             # + all optional extras (holmesgpt, vastai-sdk)
+```
+
+The `[holmes]` extra is only required on the machine that *runs* the holmes
+driver process. The core API server does not need it — HolmesGPT is invoked
+via the [driver layer](drivers.md) as a subprocess.
 
 ## Quick Navigation
 
 ### For Users
 
 - **[Quick Reference Guide](OLLAMA_QUICK_REFERENCE.md)** - Copy-paste examples and common patterns
-- **RUNE README** - Main project documentation
+- **[Deployment Modes](deployment-modes.md)** - CLI-only, Kubernetes, Docker Compose
+- **[Drivers](drivers.md)** - Pluggable agent driver architecture
 
 ### For Developers
 
 - **[Architecture Documentation](architecture.md)** - Design patterns and module reference
 - **[Compliance Targets](compliance-targets.md)** - Explicit security and compliance objectives for the repo
-- **Refactoring Summary** - What changed and why
-- **Before/After Comparison** - Visual comparison of old vs new design
-- **Detailed Refactoring Report** - Complete technical breakdown
+- **[API Compatibility Plan](API_COMPATIBILITY_PLAN.md)** - Versioning and compatibility guarantees
 
 ### Implementation Files
 
-- rune_bench/ollama/client.py - OllamaClient class
-- rune_bench/ollama/models.py - OllamaModelManager class
-- rune_bench/workflows.py - Updated to use new classes
+- rune_bench/backends/ollama.py - OllamaClient and OllamaModelManager classes
+- rune_bench/drivers/ - Pluggable driver transport layer
+- rune_bench/workflows.py - Orchestration logic
 
 ---
 
@@ -79,7 +95,7 @@ normalized = manager.normalize_model_name("ollama/mistral:latest")
 
 ## Getting Started
 
-### Installation
+### Getting started: installation
 
 No additional packages needed - uses Python standard library only.
 

--- a/docs/OLLAMA_QUICK_REFERENCE.md
+++ b/docs/OLLAMA_QUICK_REFERENCE.md
@@ -5,7 +5,7 @@
 ### List available models
 
 ```python
-from rune_bench.ollama import OllamaModelManager
+from rune_bench.backends.ollama import OllamaModelManager
 
 manager = OllamaModelManager.create("http://localhost:11434")
 models = manager.list_available_models()
@@ -35,7 +35,7 @@ print(f"Ready: {loaded}")
 ### Direct HTTP client access (advanced)
 
 ```python
-from rune_bench.ollama import OllamaClient
+from rune_bench.backends.ollama import OllamaClient
 
 client = OllamaClient("http://localhost:11434")
 models = client.get_available_models()
@@ -44,7 +44,19 @@ client.load_model("mistral:latest")
 client.unload_model("llama2:latest")
 ```
 
-### Model name normalization
+### Model name normalisation
+
+Ollama appends `:latest` when a bare name (without a tag) is requested, so
+`"tinyllama"` appears as `"tinyllama:latest"` in `/api/ps`.
+`OllamaModelManager.warmup_model()` handles this transparently via the
+`_model_in_running()` helper — both the bare name and the `:latest` variant
+are accepted:
+
+```python
+# Both of these correctly detect "tinyllama:latest" in the running-model list:
+manager.warmup_model("tinyllama")           # bare name
+manager.warmup_model("tinyllama:latest")    # explicit tag
+```
 
 ```python
 manager = OllamaModelManager.create("http://localhost:11434")
@@ -81,7 +93,7 @@ python -m rune run-benchmark \
 ## Module Structure
 
 ```text
-rune_bench.ollama
+rune_bench.backends.ollama
 ├── OllamaClient          # Low-level HTTP client
 │   ├── base_url: str
 │   ├── get_available_models() → list[str]
@@ -145,9 +157,7 @@ for model in ["mistral:latest", "llama2:latest"]:
 
 ```python
 from unittest.mock import Mock
-from rune_bench.ollama import OllamaModelManager
-
-# Create a mock client
+from rune_bench.backends.ollama import OllamaModelManager
 mock_client = Mock()
 mock_client.get_available_models.return_value = ["mistral", "llama2"]
 
@@ -161,7 +171,7 @@ assert manager.list_available_models() == ["mistral", "llama2"]
 All methods raise `RuntimeError` with descriptive messages:
 
 ```python
-from rune_bench.ollama import OllamaModelManager
+from rune_bench.backends.ollama import OllamaModelManager
 
 manager = OllamaModelManager.create("http://invalid:99999")
 
@@ -202,16 +212,13 @@ warmup_existing_ollama_model("http://localhost:11434", "mistral:latest")
 ### Adding a new method to OllamaModelManager
 
 ```python
-# In rune_bench/ollama/models.py
+# In rune_bench/backends/ollama.py
 class OllamaModelManager:
     def get_model_info(self, model_name: str) -> dict:
         """Get detailed info about a specific model."""
         models = self.client.get_available_models()
         for m in models:
             if m == model_name or m.startswith(model_name + ":"):
-                # Find full model info from /api/tags
-                # This would require extending OllamaClient.get_available_models()
-                # to return full model objects instead of just names
                 return m
         raise RuntimeError(f"Model {model_name} not found")
 ```
@@ -219,24 +226,16 @@ class OllamaModelManager:
 ### Adding a new method to OllamaClient
 
 ```python
-# In rune_bench/ollama/client.py
+# In rune_bench/backends/ollama.py
 class OllamaClient:
     def get_model_details(self, model_name: str) -> dict:
         """Get raw model info from /api/show endpoint."""
         return self._make_request(
-            f"/api/show",
+            "/api/show",
             method="POST",
             payload={"model": model_name},
             action=f"show model details for {model_name}",
         )
-```
-
-Then use in OllamaModelManager:
-
-```python
-def get_model_details(self, model_name: str) -> dict:
-    """Get detailed info about a specific model."""
-    return self.client.get_model_details(model_name)
 ```
 
 ## Troubleshooting
@@ -256,10 +255,21 @@ def get_model_details(self, model_name: str) -> dict:
 ### "Model not found"
 
 - Verify model name with `manager.list_available_models()`
-- Model names are case-sensitive and include tags (e.g., `mistral:latest`)
+- Model names are case-sensitive; a bare name like `tinyllama` is equivalent to `tinyllama:latest`
+
+## Integration tests
+
+Tests marked `@pytest.mark.integration` in `tests/test_ollama_integration.py`
+spin up a Docker Ollama container and pull TinyLlama.  They run in CI
+(`RuneGate/Ollama-Integration/TinyLlama`) but are skipped locally by default:
+
+```bash
+pytest -m "not integration"    # skip integration tests (default for local dev)
+pytest -m integration          # run integration tests (requires Docker + internet)
+```
+
+The CI job caches Ollama model files between runs to reduce pull time.
 
 ## Documentation
 
 - **API Details**: [docs/architecture.md](architecture.md)
-- **Design Comparison**: Architecture Comparison
-- **Refactoring Details**: Refactoring Details

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,15 +14,82 @@ RUNE is organized in layers:
   - Vast.ai provisioning workflow
   - Ollama model discovery/warmup orchestration
 - Provider/Domain layer:
-  - rune_bench/ollama/client.py
-  - rune_bench/ollama/models.py
+  - rune_bench/backends/ollama.py — OllamaClient and OllamaModelManager
   - rune_bench/vastai/offer.py
   - rune_bench/vastai/template.py
   - rune_bench/vastai/instance.py
   - rune_bench/common/models.py
-  - rune_bench/agents/holmes.py
+  - rune_bench/agents/sre/holmes.py — backward-compatible alias
+- Driver layer: rune_bench/drivers/
+  - DriverTransport Protocol
+  - StdioTransport and HttpTransport
+  - holmes driver (rune_bench/drivers/holmes/)
 
 This follows a thin-entrypoint pattern used by popular Python CLIs: commands are lightweight and orchestration is importable/testable.
+
+## Driver Layer
+
+HolmesGPT is decoupled from the core `rune_bench` package via a pluggable driver
+transport layer.  The core package does **not** import `holmesgpt` — the agent
+runs in a separate process and communicates over a well-defined wire protocol.
+
+### DriverTransport Protocol
+
+```python
+class DriverTransport(Protocol):
+    def call(self, action: str, params: dict) -> dict: ...
+```
+
+Any object with a matching `call` signature is a valid transport.  Two concrete
+implementations ship out of the box:
+
+| Transport | How it works |
+|-----------|-------------|
+| `StdioTransport` | Spawns a subprocess; sends one JSON line on stdin, reads one JSON line from stdout. |
+| `HttpTransport` | POSTs to `/v1/actions/{action}`, polls `/v1/jobs/{job_id}` until terminal status. |
+
+### Flow
+
+```mermaid
+flowchart LR
+    A["API / CLI"] -->|"HolmesDriverClient.ask()"| B["HolmesDriverClient"]
+    B -->|"transport.call('ask', params)"| C{"DriverTransport"}
+    C -->|"stdio (default)"| D["StdioTransport\nspawn subprocess"]
+    C -->|"http"| E["HttpTransport\nPOST + poll"]
+    D -->|"JSON on stdin/stdout"| F["python -m rune_bench.drivers.holmes"]
+    E -->|"REST"| G["Driver HTTP server"]
+    F --> H["HolmesGPT"]
+    G --> H
+```
+
+### Factory function
+
+`make_driver_transport(driver_name)` reads environment variables at call time:
+
+```python
+from rune_bench.drivers import make_driver_transport
+
+transport = make_driver_transport("holmes")
+result = transport.call("ask", {"question": "...", "model": "llama3.1:8b", ...})
+```
+
+See the [Drivers reference](drivers.md) for full env var and wire protocol details.
+
+### Module structure
+
+```text
+rune_bench/drivers/
+├── __init__.py        # make_driver_transport() factory
+├── base.py            # DriverTransport Protocol (runtime-checkable)
+├── stdio.py           # StdioTransport
+├── http.py            # HttpTransport
+└── holmes/
+    ├── __init__.py    # HolmesDriverClient (replaces old HolmesRunner internals)
+    └── __main__.py    # driver entry point: python -m rune_bench.drivers.holmes
+```
+
+`rune_bench/agents/sre/holmes.py` is a backward-compatible alias:
+`HolmesRunner = HolmesDriverClient`.
 
 ## Commands
 
@@ -81,7 +148,7 @@ These operations are implemented by:
 - `OllamaClient` (HTTP transport + JSON/error handling)
 - `OllamaModelManager` (model lifecycle, unload conflicting models, warmup polling)
 
-This keeps HTTP/API concerns in `rune_bench/ollama` and business flow in `workflows.py`.
+This keeps HTTP/API concerns in `rune_bench/backends/ollama` and business flow in `workflows.py`.
 
 ### Workflow result dataclasses
 

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -203,3 +203,32 @@ flowchart LR
 
 The `docker-compose.yml` is at the root of the `rune` repository. See its inline
 comments for GPU and production-S3 override instructions.
+
+---
+
+## Driver configuration
+
+All three modes use the driver layer to invoke HolmesGPT. The transport is
+selected per-driver via environment variables.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUNE_HOLMES_DRIVER_MODE` | `stdio` | Transport mode: `stdio` or `http` |
+| `RUNE_HOLMES_DRIVER_CMD` | `python -m rune_bench.drivers.holmes` | Stdio command to spawn (parsed with `shlex.split`) |
+| `RUNE_HOLMES_DRIVER_URL` | — | Base URL for HTTP mode (required when mode is `http`) |
+| `RUNE_HOLMES_DRIVER_TOKEN` | — | Bearer token sent to the HTTP driver server |
+| `RUNE_HOLMES_DRIVER_TENANT` | `default` | Tenant header sent to the HTTP driver server |
+
+In stdio mode (default) the driver subprocess must have `holmesgpt` installed.
+The core rune process does **not** require it.
+
+```bash
+# Override with a custom installed binary
+export RUNE_HOLMES_DRIVER_CMD=rune-holmes-driver
+
+# Use a remote HTTP driver instead of a local subprocess
+export RUNE_HOLMES_DRIVER_MODE=http
+export RUNE_HOLMES_DRIVER_URL=http://holmes-sidecar:8080
+```
+
+See [Drivers](drivers.md) for the full wire protocol and custom driver guide.

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -1,0 +1,192 @@
+# Drivers
+
+The driver layer decouples agent implementations (HolmesGPT, future SRE agents)
+from the core `rune_bench` package.  Agents run in a separate process and
+communicate with the core via a well-defined wire protocol.  This means:
+
+- The core API server and CLI do **not** require `holmesgpt` to be installed.
+- Agent implementations can be upgraded or replaced independently.
+- Custom agents can be plugged in without modifying core code.
+
+## DriverTransport Protocol
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class DriverTransport(Protocol):
+    def call(self, action: str, params: dict) -> dict:
+        """Call a driver action and return the result dict.
+
+        Raises RuntimeError on failure.
+        """
+        ...
+```
+
+Any object with a matching `call` signature satisfies the protocol — no
+inheritance required.  Two concrete implementations ship with `rune_bench`:
+
+| Class | Module | Description |
+|-------|--------|-------------|
+| `StdioTransport` | `rune_bench.drivers.stdio` | Spawns a subprocess, sends one JSON line on stdin, reads one JSON line from stdout. |
+| `HttpTransport` | `rune_bench.drivers.http` | POSTs to `/v1/actions/{action}`, polls `/v1/jobs/{job_id}` until terminal status. |
+
+## Factory function
+
+```python
+from rune_bench.drivers import make_driver_transport
+
+transport = make_driver_transport("holmes")
+result = transport.call("ask", {
+    "question": "Why is the cluster degraded?",
+    "model": "llama3.1:8b",
+    "kubeconfig_path": "/home/user/.kube/config",
+    "ollama_url": "http://localhost:11434",
+})
+answer = result["answer"]
+```
+
+`make_driver_transport(driver_name)` reads environment variables at call time.
+The variable prefix is `RUNE_<NAME>_DRIVER` where `<NAME>` is the driver name
+uppercased.
+
+## Stdio mode (default)
+
+The driver subprocess is spawned for each request, receives one JSON line on
+stdin, and must write one JSON line to stdout before exiting.
+
+### Wire protocol (v1)
+
+**Request (stdin):**
+
+```json
+{"action": "ask", "params": {"question": "...", "model": "...", ...}, "id": "UUID"}
+```
+
+**Response (stdout):**
+
+```json
+{"status": "ok", "result": {"answer": "..."}, "id": "UUID"}
+```
+
+or on failure:
+
+```json
+{"status": "error", "error": "human-readable message", "id": "UUID"}
+```
+
+The `id` field echoes the request UUID and is used for correlation in debug logs.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUNE_HOLMES_DRIVER_MODE` | `stdio` | Must be `stdio` (or omit) |
+| `RUNE_HOLMES_DRIVER_CMD` | `python -m rune_bench.drivers.holmes` | Shell command for the subprocess (parsed with `shlex.split`) |
+
+### Custom stdio command
+
+```bash
+# Use a pre-installed console script (pip install rune-bench[holmes])
+export RUNE_HOLMES_DRIVER_CMD=rune-holmes-driver
+
+# Use a different interpreter
+export RUNE_HOLMES_DRIVER_CMD="/opt/venv-holmes/bin/python -m rune_bench.drivers.holmes"
+```
+
+## HTTP mode
+
+The driver server runs as a long-lived process (or sidecar container).  Requests
+are submitted as jobs; the transport polls until completion.
+
+### HTTP mode: environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUNE_HOLMES_DRIVER_MODE` | — | Must be `http` |
+| `RUNE_HOLMES_DRIVER_URL` | — | Base URL of the driver server (required) |
+| `RUNE_HOLMES_DRIVER_TOKEN` | — | Bearer token sent in `Authorization` and `X-API-Key` headers |
+| `RUNE_HOLMES_DRIVER_TENANT` | `default` | Value of the `X-Tenant-ID` header |
+
+### HTTP endpoints (driver server must implement)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/actions/{action}` | Submit an action; body: `{"params": {...}}`; returns `202 {"job_id": "..."}` |
+| GET | `/v1/jobs/{job_id}` | Poll job status; returns `{"status": "...", "result": {...}}` |
+
+Terminal statuses: `succeeded`, `success`, `completed`, `failed`, `error`, `cancelled`.
+
+### Example
+
+```bash
+export RUNE_HOLMES_DRIVER_MODE=http
+export RUNE_HOLMES_DRIVER_URL=http://holmes-sidecar:8080
+export RUNE_HOLMES_DRIVER_TOKEN=secret
+```
+
+## Built-in drivers
+
+### `holmes`
+
+The only built-in driver.  Entry point: `python -m rune_bench.drivers.holmes`.
+
+Requires `pip install rune-bench[holmes]` in the subprocess environment.
+
+**Supported actions:**
+
+| Action | Required params | Optional params | Result |
+|--------|----------------|----------------|--------|
+| `ask` | `question`, `model`, `kubeconfig_path` | `ollama_url`, `context_window`, `max_output_tokens` | `{"answer": str}` |
+| `info` | — | — | `{"name": "holmes", "version": "1", "actions": [...]}` |
+
+The driver sets `OVERRIDE_MAX_CONTENT_SIZE` and `OVERRIDE_MAX_OUTPUT_TOKEN`
+environment variables from `context_window` / `max_output_tokens` before
+invoking HolmesGPT.
+
+`HolmesDriverClient` (in `rune_bench.drivers.holmes`) is the high-level client
+used by the rest of `rune_bench`.  `rune_bench.agents.sre.holmes.HolmesRunner`
+is a backward-compatible alias.
+
+## Writing a custom driver
+
+1. Create an executable that reads one JSON line from stdin and writes one JSON
+   line to stdout (stdio mode), or implement the HTTP job protocol (HTTP mode).
+
+2. Register it via env var:
+
+   ```bash
+   export RUNE_MYAGENT_DRIVER_CMD="python -m mypackage.myagent"
+   ```
+
+3. Call it from Python:
+
+   ```python
+   from rune_bench.drivers import make_driver_transport
+
+   transport = make_driver_transport("myagent")
+   result = transport.call("ask", {"question": "...", ...})
+   ```
+
+The driver must handle at least the `ask` action and return `{"answer": str}`.
+
+## Troubleshooting
+
+Enable debug logging to see request/response details:
+
+```bash
+export RUNE_DEBUG=1
+```
+
+Debug output includes the subprocess command, action name, request ID, and HTTP
+polling URLs.
+
+Common errors:
+
+| Error | Cause |
+|-------|-------|
+| `Failed to spawn driver process` | Command not found or not executable |
+| `Driver process produced no output` | Subprocess exited without writing to stdout |
+| `Driver process returned invalid JSON` | Subprocess wrote non-JSON to stdout (check stderr) |
+| `HTTP mode selected … URL is not set` | `RUNE_HOLMES_DRIVER_MODE=http` set without `RUNE_HOLMES_DRIVER_URL` |
+| `Driver job timed out after 3600s` | HTTP driver job did not reach a terminal status within 1 hour |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Home: INDEX.md
   - Architecture: architecture.md
   - Deployment Modes: deployment-modes.md
+  - Drivers: drivers.md
   - API Compatibility Plan: API_COMPATIBILITY_PLAN.md
   - Ollama Quick Reference: OLLAMA_QUICK_REFERENCE.md
   - Compliance Targets: compliance-targets.md


### PR DESCRIPTION
Closes #2

## Summary

Syncs documentation with all significant changes landed in the rune repository since docs were last updated.

### Changes

- **`INDEX.md`** — Rewrote home page: proper RUNE title, installation section showing `pip install rune-bench` / `rune-bench[holmes]` / `rune-bench[all]`, updated nav links
- **`architecture.md`** — Added **Driver Layer** section with Mermaid diagram showing `HolmesDriverClient → DriverTransport → StdioTransport/HttpTransport → driver process`; updated module paths to current locations
- **`deployment-modes.md`** — Added driver configuration env vars table (`RUNE_HOLMES_DRIVER_MODE`, `RUNE_HOLMES_DRIVER_CMD`, `RUNE_HOLMES_DRIVER_URL`, `RUNE_HOLMES_DRIVER_TOKEN`, `RUNE_HOLMES_DRIVER_TENANT`)
- **`OLLAMA_QUICK_REFERENCE.md`** — Fixed import paths to `rune_bench.backends.ollama`; added tag normalisation note (`tinyllama` == `tinyllama:latest`); added integration tests section
- **`docs/drivers.md`** *(new)* — Comprehensive reference: DriverTransport Protocol, stdio/HTTP wire protocol, factory function, holmes driver action spec, custom driver guide, troubleshooting
- **`mkdocs.yml`** — Added `Drivers: drivers.md` to nav

### Validation

`mkdocs build --strict` and `pymarkdown scan docs/` both pass locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>