### PR TITLE
feat: versioned MkDocs deployment to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+# Deploy MkDocs to GitHub Pages with versioned docs (mike).
+#
+# Triggers:
+#   - push of a tag matching v* (from rune cross-repo tagging)
+#   - workflow_dispatch (manual trigger)
+#
+# Each tag creates a versioned docs snapshot accessible at /v<version>/.
+# The "latest" alias always points to the newest stable release.
+#
+# Prerequisites (one-time setup):
+#   1. In rune-docs repo Settings → Pages: set source to "GitHub Actions"
+#   2. Ensure gh-pages branch exists (created automatically by first deploy)
+
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version alias (e.g. v0.0.0a1)"
+        required: false
+        default: "latest"
+
+permissions:
+  contents: write  # mike needs to push gh-pages branch
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Docs/Deploy-to-Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # mike needs full history to manage gh-pages branch
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install MkDocs and mike
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt mike
+
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version alias
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "alias=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "alias=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy versioned docs
+        run: |
+          mike deploy --push --update-aliases "${{ steps.version.outputs.alias }}" latest
+          mike set-default --push latest
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-material==9.6.14
 pymarkdownlnt==0.9.33
 pip-licenses==5.0.0
 pip-audit==2.9.0
+mike>=2.1.3


### PR DESCRIPTION
## Summary

Adds automated, **versioned** MkDocs docs deployment to GitHub Pages using [mike](https://github.com/jimporter/mike). Each rune release tag is cross-applied to this repo by `rune`'s publish workflow, which triggers this new `pages.yml`.

## Changes

- `.github/workflows/pages.yml`: new workflow — deploys docs on `v*` tag push and `workflow_dispatch`.
- `requirements.txt`: adds `mike>=2.1.3`.

## How versioning works

- **mike** manages doc versions on the `gh-pages` branch.
- Each tag (e.g. `v0.0.0a1`) creates a snapshot at `/v0.0.0a1/`.
- The `latest` alias is updated to always point to the newest release.
- `mike set-default latest` keeps the root URL redirecting to the current stable docs.

## One-time setup required

In this repo's **Settings → Pages**, set source to **"GitHub Actions"** (not the legacy branch/folder method). The `gh-pages` branch is created automatically on first deploy.

## Trigger flow

```
rune tag v0.0.0a2
  → publish-pypi.yml (rune)
    → PyPI publish
    → GitHub Release
    → cross-tags rune-docs/main with v0.0.0a2
      → pages.yml (rune-docs)  ← this PR
        → mike deploy v0.0.0a2 latest
        → GitHub Pages updated
```

## Related

Companion PR in rune: lpasquali/rune#18