### PR TITLE
ci: add concurrency cancellation to all workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Docs/Deploy-to-Pages

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   feature-docs:
     name: RuneGate/Feature/Docs


### PR DESCRIPTION
Closes #9

Adds `concurrency: cancel-in-progress: true` to quality-gates.yml and pages.yml so stale pipeline runs are cancelled when a new push arrives.