### PR TITLE
ci: switch Docker cache to GHCR registry and remove QEMU from smoke

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -104,21 +104,18 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
-      - name: Build multi-arch (amd64 + arm64)
-        uses: docker/build-push-action@v7
+      - uses: docker/login-action@v3
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: rune-docs:rune-ci-local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Load amd64 image and smoke test
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build amd64 image and smoke test
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -127,7 +124,8 @@ jobs:
           load: true
           push: false
           tags: rune-docs:rune-ci-local
-          cache-from: type=gha
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
       - run: |
           set -euo pipefail
           docker run -d --rm --name rune-docs-smoke -p 18080:80 rune-docs:rune-ci-local
@@ -149,9 +147,15 @@ jobs:
       id-token: write
       attestations: write
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
         uses: docker/build-push-action@v7
         with:
@@ -160,8 +164,8 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: rune-docs:rune-ci-local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Replace job-scoped GHA cache with cross-job GHCR registry cache for all Docker builds (quality-gates + release)
- Remove redundant multi-arch verification build from smoke job (amd64 load suffices)
- Add GHCR login and `packages: write` where needed for registry cache writes

## Expected impact
- Cross-job and cross-workflow cache sharing (release benefits from quality-gates cache)
- Smoke job eliminates ~5 min QEMU multi-arch build
- SBOM job gets cache hits instead of cold rebuilds

## Test plan
- [ ] CI passes — all quality gates green
- [ ] Smoke test builds and serves docs correctly
- [ ] SBOM generation works with registry cache

Closes #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)