### PR TITLE
feat(security): CODEOWNERS gate + OpenVEX permanent wont-fix register

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require 1 review for any change to VEX risk-acceptance documents.
+# VEX entries are security decisions — they must not be auto-merged.
+.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
-# Enforcement as a required approval depends on branch protection being
-# configured to require review from Code Owners.
-.vex/   @lpasquali
+# Enforcement requires branch protection with "Require review from Code Owners"
+# enabled. To gate only .vex/ changes while keeping other PRs review-free,
+# set required_approving_review_count=0 and enable "Require review from Code
+# Owners" — GitHub then requires 1 approval for PRs touching this path only.
+/.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# Require 1 review for any change to VEX risk-acceptance documents.
-# VEX entries are security decisions — they must not be auto-merged.
+# Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
+# Enforcement as a required approval depends on branch protection being
+# configured to require review from Code Owners.
 .vex/   @lpasquali

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -174,11 +174,11 @@ jobs:
       - name: Scan SBOM — Grype
         run: |
           set -euo pipefail
-          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 sbom:/work/sbom/rune-docs-image.cdx.json -o json > sbom/rune-docs-grype.json || true
+          docker run --rm -v "${PWD}:/work" anchore/grype:v0.82.0 sbom:/work/sbom/rune-docs-image.cdx.json --vex /work/.vex/permanent.openvex.json -o json > sbom/rune-docs-grype.json
       - name: Scan SBOM — Trivy
         run: |
           set -euo pipefail
-          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-docs-image.cdx.json --format json --output /work/sbom/rune-docs-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL || true
+          docker run --rm -v "${PWD}:/work" aquasec/trivy:0.65.0 sbom /work/sbom/rune-docs-image.cdx.json --vex /work/.vex/permanent.openvex.json --format json --output /work/sbom/rune-docs-trivy.json --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
       - name: Enforce CVE policy
         run: |
           python3 - <<'PY'

--- a/.vex/permanent.openvex.json
+++ b/.vex/permanent.openvex.json
@@ -4,7 +4,7 @@
   "author": "lpasquali",
   "role": "Project Maintainer",
   "timestamp": "2026-04-04T00:00:00Z",
-  "version": "1",
+  "version": 1,
   "statements": [
     {
       "vulnerability": { "name": "CVE-2005-2541" },

--- a/.vex/permanent.openvex.json
+++ b/.vex/permanent.openvex.json
@@ -1,10 +1,9 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://github.com/lpasquali/rune-docs/blob/main/.vex/permanent.openvex.json",
+  "@id": "urn:github:lpasquali:rune-docs:.vex:permanent.openvex.json",
   "author": "lpasquali",
   "role": "Project Maintainer",
   "timestamp": "2026-04-04T00:00:00Z",
-  "last_updated": "2026-04-04T00:00:00Z",
   "version": "1",
   "statements": [
     {
@@ -12,7 +11,7 @@
       "products": [{ "@id": "pkg:deb/debian/tar" }],
       "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
-      "impact_statement": "Debian: intended behaviour, will not fix in any release."
+      "impact_statement": "Debian: intended behaviour. The CVE describes a design choice in tar; there is no exploitable code path in this product's use of tar."
     }
   ]
 }

--- a/.vex/permanent.openvex.json
+++ b/.vex/permanent.openvex.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/lpasquali/rune-docs/blob/main/.vex/permanent.openvex.json",
+  "author": "lpasquali",
+  "role": "Project Maintainer",
+  "timestamp": "2026-04-04T00:00:00Z",
+  "last_updated": "2026-04-04T00:00:00Z",
+  "version": "1",
+  "statements": [
+    {
+      "vulnerability": { "name": "CVE-2005-2541" },
+      "products": [{ "@id": "pkg:deb/debian/tar" }],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Debian: intended behaviour, will not fix in any release."
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

### .github/CODEOWNERS
Require 1 approving review for any PR touching `.vex/` files.

### .vex/permanent.openvex.json
Seed OpenVEX register with OS-level wont-fix CVE:
- CVE-2005-2541 (Debian tar — intended behaviour, Debian won't fix)

Closes #11
Closes #13