### PR TITLE
ci: build image once, GHCR cache, parallel native arm64 release

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -111,6 +111,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -122,9 +123,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64,mode=max
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache-amd64,mode=max', github.repository_owner, github.event.repository.name) || '' }}
 
   smoke-docs-container:
     name: RuneGate/CLI-and-API-Smoke/Docs-Container

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -121,19 +121,19 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64,mode=max
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64,mode=max
 
   smoke-docs-container:
     name: RuneGate/CLI-and-API-Smoke/Docs-Container
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
@@ -144,8 +144,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull pre-built amd64 image
         run: |
-          docker pull ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
-          docker tag  ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
+          docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
       - run: |
           set -euo pipefail
           docker run -d --rm --name rune-docs-smoke -p 18080:80 rune-docs:rune-ci-local
@@ -161,13 +161,13 @@ jobs:
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       attestations: write
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3
@@ -177,8 +177,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull pre-built amd64 image
         run: |
-          docker pull ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
-          docker tag  ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
+          docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -116,17 +116,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push amd64 temp image
+      - name: Build and push amd64 temp image (same-repo)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          push: true
+          load: false
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache-amd64,mode=max', github.repository_owner, github.event.repository.name) || '' }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64,mode=max
+      - name: Build amd64 temp image (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:ci-${{ github.sha }}-amd64
 
   smoke-docs-container:
     name: RuneGate/CLI-and-API-Smoke/Docs-Container

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -99,8 +99,8 @@ jobs:
   # README-only changes skip both jobs below, saving the multi-arch Docker build
   # and the full SBOM pipeline on every documentation typo fix.
 
-  smoke-docs-container:
-    name: RuneGate/CLI-and-API-Smoke/Docs-Container
+  build-image:
+    name: RuneGate/Build/Docker-Image-amd64
     needs: [changes]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
@@ -115,17 +115,37 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build amd64 image and smoke test
+      - name: Build and push amd64 temp image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          load: true
-          push: false
-          tags: rune-docs:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
+          push: true
+          tags: ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64,mode=max
+
+  smoke-docs-container:
+    name: RuneGate/CLI-and-API-Smoke/Docs-Container
+    needs: [changes, build-image]
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
       - run: |
           set -euo pipefail
           docker run -d --rm --name rune-docs-smoke -p 18080:80 rune-docs:rune-ci-local
@@ -140,7 +160,7 @@ jobs:
 
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
-    needs: [changes]
+    needs: [changes, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -150,22 +170,15 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: rune-docs:rune-ci-local
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-docs:ci-${{ github.sha }}-amd64 rune-docs:rune-ci-local
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail
@@ -339,6 +352,7 @@ jobs:
       - changes
       - feature-docs
       - linting-docs
+      - build-image
       - smoke-docs-container
       - security-sbom
       - security-sast
@@ -352,6 +366,7 @@ jobs:
           for result in \
             "${{ needs.feature-docs.result }}" \
             "${{ needs.linting-docs.result }}" \
+            "${{ needs.build-image.result }}" \
             "${{ needs.smoke-docs-container.result }}" \
             "${{ needs.security-sbom.result }}" \
             "${{ needs.security-sast.result }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     name: Build image (arm64)
     needs: [verify-tag]
     if: github.ref_type == 'tag'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04-arm64
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,3 @@
-# Release rune-docs on version tags.
-#
-# Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
-#
-# ─── TAGGING PROCESS ────────────────────────────────────────────────────────
-#  Tags MUST only be pushed AFTER the PR has been merged to main and all
-#  quality gates (RuneGate Grouped) have passed.
-#
-#  Correct flow:
-#    1. Open PR → quality gates pass → merge to main
-#    2. git pull origin main
-#    3. git tag v<version>
-#    4. git push origin v<version>
-#
-#  NEVER push a tag on an unmerged branch or before quality gates pass.
-#  The guard step below will reject tags not reachable from origin/main.
-# ────────────────────────────────────────────────────────────────────────────
-
 name: Release
 
 on:
@@ -27,13 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Build image and create GitHub Release
+  build-amd64:
+    name: Build image (amd64)
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # Required to create GitHub Releases
-      packages: write   # Required to push to GHCR
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -50,7 +32,6 @@ jobs:
             exit 1
           fi
 
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
@@ -60,18 +41,79 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push docs image
+      - name: Build and push amd64 image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache,mode=max
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64,mode=max
+
+  build-arm64:
+    name: Build image (arm64)
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-arm64,mode=max
+
+  merge-manifest:
+    name: Create multi-arch manifest and GitHub Release
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required to create GitHub Releases
+      packages: write   # Required to push to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }} \
+            --tag ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest \
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64 \
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,27 @@ permissions:
   contents: read
 
 jobs:
+  verify-tag:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            echo "Tags must only be pushed AFTER merging to main." >&2
+            exit 1
+          fi
+
   build-amd64:
     name: Build image (amd64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
@@ -22,15 +41,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Verify tag is on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
-            echo "Tags must only be pushed AFTER merging to main." >&2
-            exit 1
-          fi
 
       - uses: docker/setup-buildx-action@v4
 
@@ -49,11 +59,12 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-amd64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64,mode=max
 
   build-arm64:
     name: Build image (arm64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -83,8 +94,8 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-docs:buildcache-arm64,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-arm64,mode=max
 
   merge-manifest:
     name: Create multi-arch manifest and GitHub Release


### PR DESCRIPTION
## Changes

### Build image once per pipeline (#30)
- New `build-image` job; smoke/sbom pull pre-built image

### GHCR registry cache (#32)
- Always-on GHCR registry cache

### Parallel native arm64 release (#33)
- `build-amd64` + `build-arm64` + `merge-manifest` in release.yml

Closes #30
Closes #32
Closes #33