### PR TITLE
ci: align Merge Gate with rune ecosystem pattern

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -374,20 +374,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify all gates passed or were skipped
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
         run: |
-          rc=0
-          for result in \
-            "${{ needs.feature-docs.result }}" \
-            "${{ needs.linting-docs.result }}" \
-            "${{ needs.build-image.result }}" \
-            "${{ needs.smoke-docs-container.result }}" \
-            "${{ needs.security-sbom.result }}" \
-            "${{ needs.security-sast.result }}" \
-            "${{ needs.security-secrets.result }}" \
-            "${{ needs.security-licenses.result }}"; do
-            echo "result: $result"
-            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-              rc=1
-            fi
-          done
-          exit $rc
+          python3 - <<'PY'
+          import json, os
+          data = json.loads(os.environ['NEEDS_JSON'])
+          failed = [(k, v.get('result')) for k, v in data.items() if v.get('result') not in ('success', 'skipped')]
+          for k, v in data.items():
+              print(f'{k}: {v.get("result")}')
+          if failed:
+              print('Merge blocked due to failing RuneGate checks:')
+              for item in failed:
+                  print(f'- {item[0]}: {item[1]}')
+              raise SystemExit(1)
+          print('All RuneGate checks passed.')
+          PY


### PR DESCRIPTION
## Summary
- Replace the bash for-loop merge gate verification with the Python-based `NEEDS_JSON` pattern used across the rune ecosystem
- Provides better diagnostics: prints all job names and their results on failure
- Consistent with the reference implementation in the main `rune` repo

Closes #21

## Test plan
- [ ] Verify the workflow runs on this PR and the "Merge Gate" check passes
- [ ] Confirm failure output includes job names and result states

Generated with [Claude Code](https://claude.com/claude-code)