### PR TITLE
[Legal] Update NOTICE file (Apache-2.0 Section 4(d))

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,20 @@
-Copyright (C) 2026 Luca Pasquali
+RUNE Docs
+Copyright 2025-2026 The Rune Authors
 
-This project is licensed under the Apache License, Version 2.0.
-See the LICENSE file for the full license text.
+This product is licensed under the Apache License, Version 2.0.
+
+This product includes software developed by third parties.
+
+---
+
+MkDocs (https://github.com/mkdocs/mkdocs)
+  License: BSD-2-Clause
+  Copyright (c) MkDocs Contributors
+
+MkDocs Material (https://github.com/squidfunk/mkdocs-material)
+  License: MIT
+  Copyright (c) Martin Donath
+
+mike (https://github.com/jimporter/mike)
+  License: BSD-3-Clause
+  Copyright (c) Jim Porter


### PR DESCRIPTION
## Summary

- Updates NOTICE file to canonical format with third-party attributions for MkDocs, Material theme, and mike

Resolves #57
Part of lpasquali/rune#133

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- NOTICE file exists at repo root with Copyright 2025-2026 The Rune Authors
- Format matches rune-operator/NOTICE canonical template
- mkdocs build --strict passes

## Audit Checks

No triggers fired. Legal metadata file only.

## Breaking Changes

None.