### PR TITLE
docs: clarify milestone compliance wording

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -22,6 +22,10 @@ Last updated: **2026-04-06**.
  
 ## Recent Changes
 
+- **P0 Issue Resolutions (2026-04-06)**: Resolved 3 critical issues across repositories:
+  - Reclassified ComfyUI to Tier 2 and added GPL-3.0 contamination warnings (`rune#131`).
+  - Enforced strict license compliance CI gates blocking GPL-2.0 variants in `rune`, `rune-ui`, and `rune-operator` (`rune#132`).
+  - Created formal Threat Model and Security Requirements specification for IEC 62443-4-1 compliance (`rune-docs#30`).
 - Consolidated documentation into `rune-docs` from all repositories.
 - Implemented modular Ollama integration with `OllamaClient` and `OllamaModelManager`.
 - Added S3 results sink for job output persistence.

--- a/docs/delivery/MILESTONES.md
+++ b/docs/delivery/MILESTONES.md
@@ -87,7 +87,7 @@ gh issue view 121 -R lpasquali/rune
 | Milestone | Target | Significance |
 |---|---|---|
 | **m4** | First beta | Feature-complete enough for external testers. Not production-ready. |
-| **m10+** | First stable release | Production-ready, fully certified (IEC 62443 ML4, SLSA L3). |
+| **m10+** | First stable release | Production-ready, fully compliant and prepared for certification (IEC 62443 ML4, SLSA L3). |
 
 Agents and developers must not assume a stable release is imminent. Current version is `0.0.0a2`. The path to stable is long and intentional — compliance, security, and quality gates will not be rushed.
 


### PR DESCRIPTION
## Summary

Clarifies compliance wording to specify preparation for certification and points to GitHub Pages site.

Closes #121
Epic: #121

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [ ] Tested in **docker-compose mode**
- [ ] Tested in **kind (Kubernetes) mode**
- [ ] Tested in **standalone CLI mode**
- [ ] **Breaking change audit**: API versions, persistent data, cross-component contracts
- [ ] **Dependency CVE audit** (if deps changed): `pip-audit` / `govulncheck` / `grype` — no new CVEs

## Level 2 Checklist

- [ ] Full test suite passes
- [ ] Coverage not degraded (at or above floor)
- [ ] No unintended CI side effects

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Wording updated.

## Test Plan Evidence

- [x] Syntax checked.

## Breaking Changes

None.

## Notes for Reviewer

None.