### PR TITLE
docs: standardize AI agent instructions (agent-neutral)

### DIFF
--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,20 @@
+# RUNE Agent Instructions
+
+All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub.
+
+Before writing or modifying code, you MUST read these files from the `rune-docs` repository:
+
+1. **[SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md)** — Architecture, protocols, constraints, SOP
+2. **[CURRENT_STATE.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CURRENT_STATE.md)** — WIP, recent changes, known issues
+3. **[CODING_STANDARDS.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md)** — Language-specific style, coverage floors
+
+Do not use local or cached project-specific instructions; use `rune-docs` as the only source of truth.
+
+## Key Principles
+
+- **Agent neutrality**: No agent is special. Use `get_agent(name)` / `get_backend(type)` factories.
+- **Config defaults, not code defaults**: Defaults live in `rune.yaml`, not Python/Go code.
+- **Pre-alpha (0.0.0)**: No backward compatibility constraints. Clean slate.
+- **97% coverage floor** (Python), **99.5% floor** (Go). No exceptions.
+- **Halt & Report**: Before executing code changes, confirm SOP steps 1-2 are complete.
+

--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -1,20 +1,51 @@
 # RUNE Agent Instructions
 
-All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub.
+All RUNE engineering standards, architecture, and SOPs are consolidated in
+the `rune-docs` repository. This file is a boot pointer — not a summary.
+Do not treat anything here as a substitute for the full documents.
 
-Before writing or modifying code, you MUST read these files from the `rune-docs` repository:
+## Mandatory Reading (in order)
 
-1. **[SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md)** — Architecture, protocols, constraints, SOP
-2. **[CURRENT_STATE.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CURRENT_STATE.md)** — WIP, recent changes, known issues
-3. **[CODING_STANDARDS.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md)** — Language-specific style, coverage floors
+Before writing or modifying any code, you MUST read these files from `rune-docs`:
 
-Do not use local or cached project-specific instructions; use `rune-docs` as the only source of truth.
+1. **[SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md)** — Architecture, protocols, constraints, SOP, Definition of Done
+2. **[CURRENT_STATE.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CURRENT_STATE.md)** — WIP, recent changes, known issues, version baseline
+3. **[CODING_STANDARDS.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md)** — Language-specific style, coverage floors, tiered agent support
+4. **[Developer Guide](https://github.com/lpasquali/rune-docs/blob/main/docs/usage/DEVELOPER_GUIDE.md)** — Repo locations, environment setup, build/test/lint commands
 
-## Key Principles
+Do not use local or cached project-specific instructions as overrides;
+`rune-docs` is the single source of truth.
 
-- **Agent neutrality**: No agent is special. Use `get_agent(name)` / `get_backend(type)` factories.
-- **Config defaults, not code defaults**: Defaults live in `rune.yaml`, not Python/Go code.
-- **Pre-alpha (0.0.0)**: No backward compatibility constraints. Clean slate.
-- **97% coverage floor** (Python), **99.5% floor** (Go). No exceptions.
-- **Halt & Report**: Before executing code changes, confirm SOP steps 1-2 are complete.
+## Anti-Rogue Constraint (non-negotiable)
 
+You MUST NOT begin the "Execute" phase of any task (writing or modifying
+code) without first explicitly confirming in the chat that:
+
+1. **SOP Step 1 (Assign)** — An issue exists and is assigned to **lpasquali**
+   (never self-assign).
+2. **SOP Step 2 (Isolate)** — You are on an isolated feature branch for this
+   task only.
+
+You MUST halt and ask the user for permission to proceed to execution,
+**regardless of whether you are operating in autonomous (YOLO) mode**.
+
+## Guard Rails
+
+These rules apply to every RUNE repository. Full details are in the
+Mandatory Reading above — these are reminders, not replacements.
+
+- **Agent & backend neutrality**: No agent or backend is privileged in code.
+  Use `get_agent(name)` / `get_backend(type)` factories.
+- **Config defaults, not code defaults**: Defaults live in `rune.yaml`, not
+  in Python or Go source.
+- **Pre-alpha**: No backward compatibility guarantees. Current version
+  baseline is in CURRENT_STATE.md.
+- **Coverage**: 97% floor (CI gate), 100% target for new code — applies to
+  both Python and Go. Tiered exceptions for Tier 2/3 agents per
+  CODING_STANDARDS.md.
+- **Branch isolation**: Only work on your assigned branch. Never modify
+  branches belonging to other agents or tasks.
+- **PR compliance**: PR bodies must match the template and check exactly one
+  DoD level (Level 1/2/3). See SYSTEM_PROMPT.md § Definition of Done.
+- **Audit triggers**: Dependency, API, supply-chain, and license changes
+  fire mandatory audit checks. See SYSTEM_PROMPT.md § Audit Agents.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,3 @@
 # Copilot Instructions
-All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub:
-https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md
+See [AGENT_INSTRUCTIONS.md](./AGENT_INSTRUCTIONS.md) for all project standards.
 
-Before suggesting code, refactoring, or performing tasks, you MUST reference the following files in the 'rune-docs' repository:
-- docs/context/SYSTEM_PROMPT.md (Core Identity & SOP)
-- docs/context/CODING_STANDARDS.md (Testing & Visuals)
-- docs/context/CURRENT_STATE.md (Living Memory)
-
-Do not use local or cached project-specific instructions; use 'rune-docs' as the only source of truth.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,12 @@
 # Copilot Instructions
-See [AGENT_INSTRUCTIONS.md](./AGENT_INSTRUCTIONS.md) for all project standards.
 
+See [AGENT_INSTRUCTIONS.md](./AGENT_INSTRUCTIONS.md) for full instructions.
+
+Before suggesting code, you MUST read these files from `rune-docs`:
+
+- [SYSTEM_PROMPT.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md) — Architecture, protocols, constraints, SOP
+- [CODING_STANDARDS.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CODING_STANDARDS.md) — Style, coverage, tiered support
+- [CURRENT_STATE.md](https://github.com/lpasquali/rune-docs/blob/main/docs/context/CURRENT_STATE.md) — WIP, versions, known issues
+
+Do not execute code changes without confirming SOP steps 1 (Assign) and
+2 (Isolate) are complete. See AGENT_INSTRUCTIONS.md for the full constraint.

--- a/docs/context/CODING_STANDARDS.md
+++ b/docs/context/CODING_STANDARDS.md
@@ -5,7 +5,7 @@
 ## Specific Stylistic Rules
 
 - **Python**: Use `black` and `ruff`. Follow PEP 8.
-- **Go**: Use `gofmt` and `staticcheck`.
+- **Go**: Use `gofmt` and `staticcheck`. Same coverage floors as Python (97% CI gate, 100% target for new code).
 - **Typing**: Use type hints in Python.
 - **Testing**:
   - **97% is the absolute floor** (CI gate); however, **100% coverage is the expected target** for all new code if achievable.


### PR DESCRIPTION
## Summary

- Creates generic `.github/AGENT_INSTRUCTIONS.md` for all AI agents
- Updates `.github/copilot-instructions.md` to redirect to generic file
- Agent-neutral: works for Claude Code, Copilot, Gemini, and any future agent

Closes #68

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- AGENT_INSTRUCTIONS.md exists in .github/
- copilot-instructions.md redirects to AGENT_INSTRUCTIONS.md

## Audit Checks

No triggers fired — documentation only.

## Breaking Changes

None.