### PR TITLE
docs: soften certification language and note PyPI URL follow-up

### DIFF
--- a/docs/delivery/MILESTONES.md
+++ b/docs/delivery/MILESTONES.md
@@ -87,7 +87,7 @@ gh issue view 121 -R lpasquali/rune
 | Milestone | Target | Significance |
 |---|---|---|
 | **m4** | First beta | Feature-complete enough for external testers. Not production-ready. |
-| **m10+** | First stable release | Production-ready, fully compliant and prepared for certification (IEC 62443 ML4, SLSA L3). |
+| **m10+** | First stable release | Production-ready, designed to meet all requirements for certification (IEC 62443 ML4, SLSA L3). |
 
 Agents and developers must not assume a stable release is imminent. Current version is `0.0.0a2`. The path to stable is long and intentional — compliance, security, and quality gates will not be rushed.
 

--- a/docs/security/RISK_REGISTER.md
+++ b/docs/security/RISK_REGISTER.md
@@ -30,7 +30,7 @@ treatment, and reviewed on a regular cadence.
 | R-012 | Repudiation | Incomplete audit trail for Vast.ai instance lifecycle events; manual operations are not logged. | 3 | 3 | 9 | Mitigate | lpasquali | Open | 2026-07-01 |
 | R-013 | Denial of Service | MkDocs documentation site denial of service via resource exhaustion (low impact; static site behind CDN). | 1 | 1 | 1 | Accept | lpasquali | Accepted | 2026-07-01 |
 | R-014 | Supply Chain | Container base image (Python/Go) contains unpatched CVEs. Mitigated by SBOM + Grype/Trivy scanning in CI; unfixable CVEs tracked in VEX. | 3 | 3 | 9 | Mitigate | lpasquali | Open | 2026-07-01 |
-| R-015 | Compliance | IEC 62443-4-1 certification evidence gaps. This risk register and supporting security documents address the documentation gaps. | 2 | 4 | 8 | Mitigate | lpasquali | In Progress | 2026-07-01 |
+| R-015 | Compliance | IEC 62443-4-1 certification evidence gaps. This risk register and supporting security documents are being developed to address the documentation gaps. | 2 | 4 | 8 | Mitigate | lpasquali | In Progress | 2026-07-01 |
 
 ## 3. Risk Score Summary
 


### PR DESCRIPTION
## Summary
- Soften "fully compliant" → "designed to meet all requirements for certification" in `MILESTONES.md`
- Clarify risk register R-015 as in-progress ("being developed to address") in `RISK_REGISTER.md`

Closes #64

### Remaining cross-repo work (separate PRs)
- `rune-audit/README.md`: soften "aligns with" and "is verified against" (lines 92-96)
- `rune/pyproject.toml`: update Homepage URL to docs section
- `rune-ui/pyproject.toml`: update Homepage URL to UI docs section
- `rune-audit/pyproject.toml`: update Homepage URL to audit docs section

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] No rune-docs file claims current IEC 62443 or SLSA certification
- [x] `mkdocs build --strict` passes

## Audit Checks

No triggers fired — documentation-only change.

## Breaking Changes

None.

## Test plan

- [x] `mkdocs build --strict` — passes
- [x] Before/after: "fully compliant" → "designed to meet all requirements for certification"
- [x] Before/after: "address the documentation gaps" → "being developed to address the documentation gaps"

🤖 Generated with [Claude Code](https://claude.com/claude-code)