### PR TITLE
fix: strengthen VEX nginx justifications with specific technical evidence

### DIFF
--- a/.vex/permanent.openvex.json
+++ b/.vex/permanent.openvex.json
@@ -30,24 +30,24 @@
     },
     {
       "vulnerability": { "name": "CVE-2024-56171" },
-      "products": [{ "@id": "pkg:apk/alpine/nginx" }],
+      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Vulnerability isolated to unused component."
+      "impact_statement": "CVE-2024-56171 affects libxml2 xmlSchemaIDCFillNodeTables (XML Schema validation). libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static HTML/CSS/JS files; no XML parsing or schema validation occurs. The vulnerable code path is unreachable in this deployment."
     },
     {
       "vulnerability": { "name": "CVE-2025-49794" },
-      "products": [{ "@id": "pkg:apk/alpine/nginx" }],
+      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Vulnerability isolated to unused component."
+      "impact_statement": "CVE-2025-49794 is a use-after-free and type confusion vulnerability in libxml2 xmlSchematronGetNode (Schematron validation module). libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static files; no XML or Schematron parsing occurs. The vulnerable code path is unreachable in this deployment."
     },
     {
       "vulnerability": { "name": "CVE-2025-49796" },
-      "products": [{ "@id": "pkg:apk/alpine/nginx" }],
+      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Vulnerability isolated to unused component."
+      "impact_statement": "CVE-2025-49796 is a type confusion vulnerability in libxml2 Schematron module. libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static files; no XML or Schematron parsing occurs. The vulnerable code path is unreachable in this deployment."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace generic "Vulnerability isolated to unused component" VEX justifications with specific technical analysis
- All three CVEs (CVE-2024-56171, CVE-2025-49794, CVE-2025-49796) are **libxml2 vulnerabilities**, not nginx
- Corrects product PURL from `pkg:apk/alpine/nginx` to `pkg:apk/alpine/libxml2`

Closes #34

### Technical evidence
- `ldd /usr/sbin/nginx` on `nginx:1.27.4-alpine`: **nginx does not link to libxml2**
- libxml2 2.13.4 is present in Alpine base image but unused by nginx process
- rune-docs serves static HTML/CSS/JS only — no XML parsing or Schematron validation
- CVE-2024-56171: `xmlSchemaIDCFillNodeTables` (XML Schema validation) — unreachable
- CVE-2025-49794: `xmlSchematronGetNode` use-after-free + type confusion — unreachable
- CVE-2025-49796: Schematron module type confusion — unreachable

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] Each CVE entry names the specific libxml2 module/function affected
- [x] Each justification documents nginx does not link to libxml2 (`ldd` verification)
- [x] Each justification references the static-file-only nginx config
- [x] `.vex/permanent.openvex.json` parses as valid JSON
- [x] Product PURLs corrected to `pkg:apk/alpine/libxml2`
- [x] No `not_affected` status retained for a CVE where the module is confirmed linked

## Audit Checks

`cyber check:vex` — VEX statements modified in `.vex/permanent.openvex.json`. No triggers fired for other categories.

## Breaking Changes

None.

## Test plan

- [x] `python3 -c "import json; json.load(open('.vex/permanent.openvex.json'))"` — PASS
- [x] `docker run --rm nginx:1.27.4-alpine ldd /usr/sbin/nginx` — no libxml2 reference
- [x] Each impact statement >80 chars (403, 433, 380 respectively)
- [x] `mkdocs build --strict` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)