### PR TITLE
docs: add rollback procedures and security training records (SUM-4, SM-3)

### DIFF
--- a/docs/operations/ROLLBACK_PROCEDURES.md
+++ b/docs/operations/ROLLBACK_PROCEDURES.md
@@ -1,0 +1,113 @@
+# Rollback Procedures
+
+IEC 62443-4-1 SUM-4 requires documented rollback procedures for all deployment artifacts.
+
+## Kubernetes Deployments (Helm)
+
+### Chart Rollback
+
+```bash
+# List release history
+helm history rune -n rune
+
+# Rollback to previous revision
+helm rollback rune <revision> -n rune
+
+# Verify rollback
+kubectl get pods -n rune -w
+helm status rune -n rune
+```
+
+### Operator Rollback
+
+```bash
+helm rollback rune-operator <revision> -n rune-system
+kubectl get pods -n rune-system -w
+```
+
+### UI Rollback
+
+```bash
+helm rollback rune-ui <revision> -n rune
+```
+
+## Container Image Rollback
+
+If a new image introduces a regression:
+
+```bash
+# Pin to previous known-good tag
+helm upgrade rune rune/rune \
+  --set image.tag=v0.0.0a4 \
+  -n rune
+
+# Verify pods are running the correct image
+kubectl get pods -n rune -o jsonpath='{.items[*].spec.containers[*].image}'
+```
+
+## Database Schema Rollback
+
+RUNE uses SQLite for job persistence. The database file is stored in a persistent volume.
+
+### Pre-upgrade Backup
+
+Before any upgrade that modifies the SQLite schema:
+
+```bash
+# Backup the database
+kubectl exec -n rune deploy/rune-api -- cp /data/jobs.db /data/jobs.db.bak
+
+# Verify backup
+kubectl exec -n rune deploy/rune-api -- ls -la /data/jobs.db.bak
+```
+
+### Restore from Backup
+
+```bash
+kubectl exec -n rune deploy/rune-api -- cp /data/jobs.db.bak /data/jobs.db
+kubectl rollout restart deploy/rune-api -n rune
+```
+
+## Release Rollback (PyPI)
+
+PyPI does not support true rollback — only yanking. If a bad release is published:
+
+1. Yank the bad version: `twine yank rune-bench==<bad-version>`
+2. Users can pin to the previous version: `pip install rune-bench==<good-version>`
+
+## Air-Gapped Environment Rollback
+
+See [rune-airgapped upgrade/rollback scripts](https://github.com/lpasquali/rune-airgapped) (Issue #13).
+
+For air-gapped clusters:
+
+1. Keep the previous OCI bundle tarball on the bootstrap node.
+2. Re-run `bootstrap.sh` with the previous bundle.
+3. Helm releases are rolled back automatically when the previous chart versions are applied.
+
+## Emergency Shutdown
+
+If a rollback is insufficient and the system must be stopped immediately:
+
+```bash
+# Suspend all scheduled benchmarks
+kubectl patch runebenchmark --all -n rune --type merge -p '{"spec":{"suspend":true}}'
+
+# Scale down all RUNE workloads
+kubectl scale deploy --all -n rune --replicas=0
+kubectl scale deploy --all -n rune-system --replicas=0
+```
+
+## Verification After Rollback
+
+After any rollback, run the health check script:
+
+```bash
+./scripts/health-check.sh --namespace rune
+```
+
+Confirm:
+- All pods are Running with zero recent restarts
+- `/healthz` endpoints return `200 OK`
+- Job history is intact (no data loss)
+- Scheduled benchmarks resume correctly (if unsuspended)

--- a/docs/security/SECURITY_TRAINING.md
+++ b/docs/security/SECURITY_TRAINING.md
@@ -1,0 +1,56 @@
+# Security Training and Competency Records
+
+IEC 62443-4-1 SM-3 requires that all personnel involved in the secure development lifecycle have documented security training and competency verification.
+
+## Training Requirements
+
+### Mandatory Training (All Contributors)
+
+| Topic | Frequency | Verification |
+|---|---|---|
+| OWASP Top 10 (Web) | Annual | Quiz or certification |
+| Secure coding practices (Python, Go) | Annual | Code review participation |
+| Supply chain security (SLSA, SBOM, VEX) | Annual | Tooling proficiency demo |
+| IEC 62443 awareness | At onboarding + annual | Self-assessment |
+| Incident response procedures | Annual | Tabletop exercise participation |
+
+### Role-Specific Training
+
+| Role | Additional Training | Frequency |
+|---|---|---|
+| Maintainer | Threat modeling (STRIDE), Sigstore/cosign | Annual |
+| CI/CD contributor | GitHub Actions security, secret management | Per-change |
+| Helm chart author | Kubernetes security (PSA, RBAC, NetworkPolicy) | Annual |
+
+## Current Training Records
+
+### 2025-2026 Pre-Alpha Phase
+
+| Person | Role | Training Completed | Date | Evidence |
+|---|---|---|---|---|
+| lpasquali | Maintainer, sole developer | OWASP Top 10, IEC 62443 awareness, SLSA L3 tooling, threat modeling (STRIDE), Sigstore/cosign | 2025-2026 (ongoing) | SDL policy authored (SM-1), risk register created (SM-5), SBOM pipeline implemented, container signing implemented |
+
+> **Note:** During the pre-alpha solo-maintainer phase, training is self-directed and evidenced
+> by the security artifacts produced. Formal third-party training certifications will be pursued
+> as the team grows and the project approaches its first stable release.
+
+## Competency Verification
+
+Competency is verified through:
+
+1. **Code review participation** — security-relevant PRs require review comments demonstrating understanding of the threat model.
+2. **Security artifact authorship** — SDL, risk register, VEX documents, incident response plans.
+3. **CI/CD pipeline design** — SAST, SCA, SBOM, container signing, and provenance attestation pipelines.
+4. **Incident response exercises** — documented tabletop or live exercises.
+
+## Training Gap Remediation
+
+If a training gap is identified (e.g., a new technology is adopted without corresponding training):
+
+1. The gap is logged in the [Risk Register](RISK_REGISTER.md) as a compliance risk.
+2. Training is scheduled within 30 days.
+3. The risk entry is updated upon completion.
+
+## Renewal Schedule
+
+All training records are reviewed at each milestone exit. Expired training (>12 months) blocks milestone sign-off per SM-3.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Deployment: operations/DEPLOYMENT.md
       - Observability: operations/OBSERVABILITY.md
       - Runbooks: operations/RUNBOOKS.md
+      - Rollback Procedures: operations/ROLLBACK_PROCEDURES.md
       - Vault Integration: operations/VAULT.md
   - Security:
       - Security Development Lifecycle: security/SDL.md
@@ -55,6 +56,7 @@ nav:
       - Fuzz Testing: security/FUZZ_TESTING.md
       - Incident Response: security/INCIDENT_RESPONSE.md
       - Container Image Signing: security/IMAGE_SIGNING.md
+      - Security Training Records: security/SECURITY_TRAINING.md
   - Architecture:
       - Threat Model: architecture/THREAT_MODEL.md
       - Security Requirements: architecture/SECURITY_REQUIREMENTS.md


### PR DESCRIPTION
## Summary
- Add `ROLLBACK_PROCEDURES.md` — IEC 62443-4-1 SUM-4 compliance (Helm, image, DB, PyPI, airgapped rollback)
- Add `SECURITY_TRAINING.md` — IEC 62443-4-1 SM-3 compliance (training matrix, records, competency verification)
- Add both to mkdocs.yml navigation

Closes #35
Closes #36

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] Rollback procedures documented for Kubernetes, container images, database, PyPI, and airgapped
- [x] Security training requirements matrix documented
- [x] Current training records documented for sole maintainer
- [x] Competency verification procedures defined
- [x] `mkdocs build --strict` passes

## Audit Checks

No triggers fired — documentation-only changes.

## Breaking Changes

None.

## Test plan

- [x] `mkdocs build --strict` — passes
- [x] Both new pages accessible in nav (Operations > Rollback Procedures, Security > Security Training Records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)