### PR TITLE
ci: add SBOM generation and release asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,14 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64 \
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
 
+      - name: Generate SBOM
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            anchore/syft:v1.42.3 \
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64 \
+            -o cyclonedx-json=sbom.cdx.json
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,3 +145,10 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             --verify-tag
+
+      - name: Upload SBOM to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" sbom.cdx.json \
+            --clobber


### PR DESCRIPTION
## Summary
- Generate CycloneDX SBOM via Syft after multi-arch manifest creation
- Upload `sbom.cdx.json` as GitHub Release asset for permanent retention
- Satisfies NIST SP 800-218 PS.3 (SBOM retained with release lifecycle)

Closes #43

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure (CI workflow change only)
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] Release workflow generates SBOM via Syft
- [x] SBOM uploaded as release asset (`sbom.cdx.json`)
- [x] Retained indefinitely (tied to release, not 14-day artifact)

## Audit Checks

| Check | Result |
|---|---|
| `cyber check:supply-chain` | PASS — CI workflow modified, adds SBOM retention |

## Breaking Changes

None.

## Test plan

- [x] Workflow syntax valid (no YAML errors)
- [x] Will be validated on next tag push (release workflow is tag-triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)