### PR TITLE
ci: migrate release.yml to shared rune-ci workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 name: Release
 
 on:
@@ -6,173 +7,15 @@ on:
       - "v*"
 
 permissions:
-  contents: read
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
 
 jobs:
-  verify-tag:
-    name: Verify tag is on main
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-      - name: Verify tag is on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
-            echo "Tags must only be pushed AFTER merging to main." >&2
-            exit 1
-          fi
-
-  build-amd64:
-    name: Build image (amd64)
-    needs: [verify-tag]
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push amd64 image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-amd64,mode=max
-
-  build-arm64:
-    name: Build image (arm64)
-    needs: [verify-tag]
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push arm64 image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/arm64
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-arm64
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache-arm64,mode=max
-
-  merge-manifest:
-    name: Create multi-arch manifest and GitHub Release
-    needs: [build-amd64, build-arm64]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write        # Required to create GitHub Releases
-      packages: write        # Required to push to GHCR
-      id-token: write        # Required for SLSA provenance attestation
-      attestations: write    # Required for attestation
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push multi-arch manifest
-        id: manifest
-        run: |
-          docker buildx imagetools create \
-            --tag ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }} \
-            --tag ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest \
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64 \
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-arm64
-
-          # Fetch the manifest digest for attestation (crane outputs clean sha256:...)
-          DIGEST=$(docker buildx imagetools inspect \
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }} \
-            --format '{{.Manifest.Digest}}' 2>/dev/null \
-            | grep -oP 'sha256:[a-f0-9]+' | head -1)
-          if [ -z "$DIGEST" ]; then
-            # Fallback: parse from imagetools inspect raw output
-            DIGEST=$(docker buildx imagetools inspect \
-              ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }} \
-              2>&1 | grep -oP 'Digest:\s+\Ksha256:[a-f0-9]+' | head -1)
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Install Syft
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
-
-      - name: Generate SBOM
-        run: |
-          syft ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}-amd64 \
-            -o cyclonedx-json=sbom.cdx.json
-
-      - name: Attest build provenance — SLSA L3
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
-          push-to-registry: true
-
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            --verify-tag
-
-      - name: Upload SBOM to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ github.ref_name }}" sbom.cdx.json \
-            --clobber
+  release:
+    uses: lpasquali/rune-ci/.github/workflows/release.yml@v0.1.0
+    with:
+      image-name: rune-docs
+      generate-sbom: true
+      slsa-attestation: true


### PR DESCRIPTION
## Summary
- Replace 179-line monolithic `release.yml` with a 21-line thin caller to `lpasquali/rune-ci/.github/workflows/release.yml@v0.1.0`
- Passes `image-name: rune-docs`, `generate-sbom: true`, `slsa-attestation: true`
- Adds SPDX license header
- No `notify-charts` needed for rune-docs

Closes lpasquali/rune-docs#149

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] Workflow file is a valid thin caller referencing `lpasquali/rune-ci/.github/workflows/release.yml@v0.1.0`
- [x] Same trigger preserved: `on: push: tags: v*`
- [x] Inputs match requirements: `image-name`, `generate-sbom`, `slsa-attestation`
- [x] SPDX license header present
- [x] Permissions block includes `contents: write`, `packages: write`, `id-token: write`, `attestations: write` (required by reusable workflow)

## Audit Checks
| Check | Result |
|---|---|
| `cyber check:supply-chain` | PASS — CI workflow modified to call pinned reusable workflow at `@v0.1.0`; no inline scripts, no unpinned actions |

## Breaking Changes
None. The reusable workflow preserves the same release behavior (tag verification, multi-arch build, manifest creation, SBOM generation, SLSA attestation, GitHub Release creation).

## Test plan
- [x] Verified thin caller YAML is syntactically valid
- [x] Confirmed reusable workflow at `lpasquali/rune-ci/.github/workflows/release.yml` accepts the passed inputs (`image-name`, `generate-sbom`, `slsa-attestation`)
- [x] CI will validate on next tag push