### PR TITLE
ci: standardize project-sync to rune-ci reusable workflow

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@063ed73b40bf986310a32ee32dc8e21e0a39aa55 # main
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
Standardize project-sync.yml to use the rune-ci reusable component.
This resolves an issue where epics, issues, and PRs were not correctly transitioning on the project board when labeled or assigned.

Closes #1

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] Project sync references the reusable workflow from rune-ci.

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] Workflow syntax is correct.