### PR TITLE
docs: add advanced pipeline and database guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ How to interact with and configure RUNE.
 
 - **[QUICKSTART](docs/usage/QUICKSTART.md)** — Getting started locally.
 - **[INTERFACES](docs/usage/INTERFACES.md)** — CLI commands and API endpoints.
+- **[ADVANCED_PIPELINES](docs/usage/ADVANCED_PIPELINES.md)** — Chain DAG and audit artifact views.
 - **[CONFIGURATION](docs/usage/CONFIGURATION.md)** — Environment variables and files.
 
 ## 🚀 Delivery
@@ -31,6 +32,7 @@ How RUNE is built, tested, and shipped.
 How RUNE is hosted and maintained.
 
 - **[DEPLOYMENT](docs/operations/DEPLOYMENT.md)** — Hosting modes and provisioning.
+- **[DATABASE](docs/operations/DATABASE.md)** — Current SQLite operations and planned PostgreSQL rollout.
 - **[OBSERVABILITY](docs/operations/OBSERVABILITY.md)** — Metrics and logging.
 - **[RUNBOOKS](docs/operations/RUNBOOKS.md)** — Incident response checklists.
 

--- a/docs/architecture/INFRASTRUCTURE.md
+++ b/docs/architecture/INFRASTRUCTURE.md
@@ -21,7 +21,11 @@ Networking, scaling limits, and dependencies for RUNE.
  
 ## Scaling Limits
 
-- **Concurrency**: SQLite-backed job store limits high-volume concurrent writes. For large-scale use, consider PostgreSQL (future ADR).
+- **Concurrency**: SQLite-backed job storage is simple and reliable for
+  single-node or single-pod deployments, but it limits high-volume concurrent
+  writes and does not provide a shared store for multiple `rune-api` replicas.
+  The accepted PostgreSQL direction is documented in
+  **[ADR 0006](adrs/0006-storage-abstraction-postgres.md)**.
 - **Vast.ai Limits**: Subject to provider availability and account limits.
 - **Model Size**: Limited by target machine GPU memory (VRAM).
 

--- a/docs/architecture/SYSTEM_DESIGN.md
+++ b/docs/architecture/SYSTEM_DESIGN.md
@@ -17,7 +17,7 @@ flowchart TD
 
     subgraph "Control Plane (RUNE Core)"
         API["rune-api\n(ThreadingHTTPServer)"]
-        STORE[("Job Store\n(SQLite)")]
+        STORE[("Job Store\n(SQLite today /\nPostgreSQL planned)")]
         WF["Workflows\n(Orchestration)"]
     end
 
@@ -47,6 +47,10 @@ flowchart TD
     WF --> S3
     WF --> MET
 ```
+
+The current released runtime remains SQLite-backed. The PostgreSQL direction is
+accepted but still in progress; see
+[ADR 0006](adrs/0006-storage-abstraction-postgres.md).
 
  
 ## Repository Layout

--- a/docs/architecture/adrs/0006-storage-abstraction-postgres.md
+++ b/docs/architecture/adrs/0006-storage-abstraction-postgres.md
@@ -1,0 +1,104 @@
+# ADR 0006: Storage Abstraction and External PostgreSQL
+
+## Status
+
+Accepted (implementation in progress)
+
+## Context
+
+RUNE's job persistence is currently backed by embedded SQLite. That is still the
+right default for local development, single-pod Kubernetes deployments, and
+simple airgapped installations, but it creates structural limits:
+
+1. A single SQLite file is not the right coordination point for multiple
+   `rune-api` replicas behind one Service.
+2. Compliance-heavy deployments want audit evidence and run state in a managed
+   database, not an embedded file inside the application pod.
+3. New storage-backed features such as chain state and audit artifacts should
+   inherit a backend-neutral storage contract instead of deepening the
+   SQLite-only assumption.
+
+The implementation has already started. `rune` now exposes a `StoragePort`
+protocol, a `SQLiteStorageAdapter`, and a hand-rolled SQL migration framework.
+What is not finished yet is the Postgres adapter, runtime config selection, and
+the deployment story around it.
+
+## Decision
+
+RUNE will support two storage backends behind the same storage interface:
+
+1. **SQLite remains the default** for low-complexity installs.
+2. **PostgreSQL becomes the supported external database** for multi-pod,
+   production, and audit-heavy deployments.
+
+### Runtime shape
+
+- The storage layer is selected by URL, not by branching application logic.
+- The current shipped URL support is `sqlite://...`.
+- `RUNE_DB_URL` is the planned runtime selector for both SQLite and Postgres
+  once the config work is complete.
+- Application code continues to depend on the storage interface, not on
+  backend-specific SQL.
+
+### Migrations
+
+- RUNE uses a hand-rolled migration loader with a `schema_version` table.
+- Migration files live as ordered `.sql` files and are applied in lexicographic
+  order inside explicit transactions.
+- Re-applying migrations is designed to be idempotent.
+
+### Deployment
+
+- The simple packaged Postgres path is a **first-party Helm subchart** in
+  `rune-charts`, wrapping the official `docker.io/library/postgres:17-alpine`
+  image.
+- High-availability PostgreSQL is documented as **BYO CloudNativePG**, not a
+  bundled dependency.
+- The airgapped bundle will include the approved Postgres image once the chart
+  and runtime support are ready.
+
+## Licensing and Supply-Chain Constraints
+
+The database choice is constrained by licensing and by the project-wide
+no-proprietary / no-fragile-supply-chain rules.
+
+| Option | Decision | Why |
+|---|---|---|
+| PostgreSQL upstream + `postgres:17-alpine` | Approved | PostgreSQL License plus Docker Official Image maintenance |
+| First-party `rune-charts/charts/postgres` subchart | Approved | No third-party chart dependency; minimal supply chain |
+| CloudNativePG | Approved as BYO | Apache 2.0, CNCF path for HA, not bundled |
+| `psycopg[binary]` / `psycopg[pure]` | Approved | Apache 2.0 wrapper around `libpq` |
+| Bitnami PostgreSQL chart | Rejected | Legacy Broadcom/Tanzu transition and supply-chain concerns |
+| StackGres | Rejected | AGPLv3 |
+| Bundled MariaDB / MySQL server | Rejected | GPL server bundling risk for shipped images |
+| CockroachDB | Rejected | BUSL on current releases |
+
+## Implementation Status
+
+As of **2026-04-09**:
+
+- Done:
+  - `rune#231` — `StoragePort` extraction and `SQLiteStorageAdapter`
+  - `rune#232` — hand-rolled migrations framework
+- In progress / still open:
+  - `rune#233` — `PostgresStorageAdapter`
+  - `rune#234` — `RUNE_DB_URL` config and backend selection
+  - `rune#235` — `rune db migrate-to-postgres`
+  - `rune#236` — Postgres integration test matrix
+  - `rune-charts#71` — first-party Postgres subchart
+  - `rune-airgapped#63` — bundle Postgres image
+  - `rune-docs#196` — end-user database operations guides
+
+This ADR intentionally lands before the final operations guides. The operator
+runbooks, connection-string reference, and HA procedures should only be written
+once the runtime config and Helm story exist in released code.
+
+## Consequences
+
+- Existing SQLite users keep a stable default path and do not need to migrate
+  immediately.
+- The storage interface becomes the boundary for future persistence changes.
+- The eventual Postgres rollout can be documented and tested without rewriting
+  application code again.
+- Until `rune#234` lands, public docs must clearly state that external Postgres
+  support is a planned capability rather than a released one.

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -32,6 +32,38 @@ Last updated: **2026-04-09**.
  
 ## Recent Changes
 
+### 2026-04-09 — Advanced pipelines docs + database roadmap ADR
+
+**`ADVANCED_PIPELINES.md`** added to document the now-shipped chain DAG and
+audit artifact views:
+
+- `/chains/{run_id}` backed by `GET /v1/chains/{run_id}/state`
+- `/audits/{run_id}` backed by `GET /v1/audits/{run_id}/artifacts`
+- Payload shapes, validation steps, and artifact-kind coverage now live in one
+  user-facing page
+
+**`API_SPEC.md` and `INTERFACES.md`** updated to include the chain-state and
+audit-artifact endpoints so the published docs reflect the merged `rune` and
+`rune-ui` features behind rune-docs#175.
+
+**ADR 0006** added for external database support (rune-docs#195):
+
+- SQLite remains the shipped default today
+- PostgreSQL is the accepted direction for multi-pod and audit-heavy
+  deployments
+- Supply-chain and licensing decisions are now written down in docs
+- Implementation status is explicit: `rune#231` and `rune#232` are done, while
+  Postgres adapter/config/chart/docs work remains open
+- `DATABASE.md` and `DATABASE_HA.md` now document the current SQLite reality and
+  the planned PostgreSQL/CNPG operating model without claiming the runtime work
+  is finished
+
+**Current docs clarified**:
+
+- `DEPLOYMENT.md`, `INFRASTRUCTURE.md`, `CONFIGURATION.md`, and
+  `DEVELOPER_GUIDE.md` now distinguish **current SQLite support** from the
+  **planned PostgreSQL rollout**
+
 ### 2026-04-09 — Hybrid project board sync (Epic rune-docs#187 closed)
 
 Consolidated project board automation by splitting Status field ownership (Projects v2 built-in workflows) from Agent Lane ownership (slimmed `rune-ci/project-sync-logic.yml`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ How to interact with and configure RUNE.
 
 - **[QUICKSTART](usage/QUICKSTART.md)** — Getting started locally.
 - **[INTERFACES](usage/INTERFACES.md)** — CLI commands and API endpoints.
+- **[ADVANCED_PIPELINES](usage/ADVANCED_PIPELINES.md)** — Chain DAG and audit artifact views.
 - **[CONFIGURATION](usage/CONFIGURATION.md)** — Environment variables and files.
 
 ## 🚀 Delivery
@@ -31,6 +32,7 @@ How RUNE is built, tested, and shipped.
 How RUNE is hosted and maintained.
 
 - **[DEPLOYMENT](operations/DEPLOYMENT.md)** — Hosting modes and provisioning.
+- **[DATABASE](operations/DATABASE.md)** — Current SQLite operations and planned PostgreSQL rollout.
 - **[OBSERVABILITY](operations/OBSERVABILITY.md)** — Metrics and logging.
 - **[RUNBOOKS](operations/RUNBOOKS.md)** — Incident response checklists.
 

--- a/docs/operations/DATABASE.md
+++ b/docs/operations/DATABASE.md
@@ -1,0 +1,159 @@
+# Database Operations
+
+## Status
+
+**Current release status:** RUNE ships with **SQLite** as the supported runtime
+store today.
+
+External PostgreSQL support is an accepted direction and parts of the storage
+refactor are already merged, but the Postgres adapter, runtime selection, Helm
+subchart, and migration CLI are **not all released yet**. This page therefore
+documents both:
+
+- what is **supported now**
+- what is the **planned operational model** once the remaining work lands
+
+Track implementation status in
+[ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md).
+
+## Decision Matrix
+
+| Deployment shape | Recommended store | Status today | Why |
+|---|---|---|---|
+| Local development | SQLite | Supported | Lowest friction, no extra service |
+| Single-pod Kubernetes | SQLite | Supported | Embedded persistence is sufficient |
+| Simple airgapped install | SQLite | Supported | Fewer moving parts and smaller bundle |
+| Multi-pod `rune-api` deployment | PostgreSQL | Planned | Shared network database for multiple replicas |
+| Audit-heavy / compliance-focused production | PostgreSQL | Planned | Centralized persistence and cleaner separation from app pods |
+| HA / multi-AZ / PITR requirements | PostgreSQL + CNPG | Planned | SQLite is not the right HA substrate |
+
+## Current Supported Configuration
+
+Today the supported persistence knob is:
+
+- `RUNE_API_DB_PATH=.rune-api/jobs.db`
+
+That points `rune-api` at the embedded SQLite file used by the current runtime.
+
+Example:
+
+```bash
+export RUNE_API_DB_PATH=/var/lib/rune/jobs.db
+python -m rune.api
+```
+
+## Planned URL-Based Storage Selection
+
+The storage layer is moving toward URL-based backend selection behind the same
+storage interface. The planned runtime variable is `RUNE_DB_URL`, but it is
+**not yet the released public contract**.
+
+### Planned SQLite URL forms
+
+```text
+sqlite:///:memory:
+sqlite:///var/lib/rune/jobs.db
+```
+
+### Planned PostgreSQL URL forms
+
+```text
+postgresql://rune:secret@postgres.rune.svc.cluster.local:5432/rune
+postgresql://rune:${DB_PASSWORD}@db.example.internal:5432/rune?sslmode=require
+```
+
+Use these as target formats for rollout planning only until `rune#234` lands.
+
+## Migrations Framework
+
+The hand-rolled migration framework is already part of the storage layer.
+
+### How it works
+
+- Ordered `.sql` files are applied in lexicographic order
+- Applied versions are tracked in `schema_version`
+- Migrations run inside explicit transactions
+- Re-running pending migrations is designed to be idempotent
+- Legacy SQLite databases without `schema_version` are bootstrapped by
+  pre-seeding known migration versions
+
+This keeps the persistence layer simple and auditable without pulling in
+SQLAlchemy/Alembic.
+
+## Backup and Restore
+
+### SQLite
+
+SQLite is the only store you should operate in production today.
+
+Backup:
+
+```bash
+sqlite3 /var/lib/rune/jobs.db ".backup '/var/backups/rune/jobs-$(date +%F).db'"
+```
+
+Restore:
+
+```bash
+cp /var/backups/rune/jobs-2026-04-09.db /var/lib/rune/jobs.db
+```
+
+Operational notes:
+
+- Stop `rune-api` or ensure the file is copied atomically during your backup
+  procedure.
+- Back up the persistent volume, not just the container filesystem.
+
+### PostgreSQL (planned support)
+
+Once the Postgres adapter is released, the normal backup primitives will be:
+
+- logical backups with `pg_dump`
+- replica/base backups with `pg_basebackup`
+- operator-managed snapshots when using CloudNativePG
+
+Those flows are intentionally not described as current RUNE runtime procedures
+yet, because the runtime integration is still blocked on `rune#233` and
+`rune#234`.
+
+## Migration Path: Embedded SQLite to PostgreSQL
+
+The planned graduation path is:
+
+1. Run the SQLite-backed deployment until your scaling or compliance needs
+   require a shared external store.
+2. Provision PostgreSQL via the first-party `rune-charts` subchart or your own
+   managed service.
+3. Run the planned `rune db migrate-to-postgres` command.
+4. Switch runtime configuration to the Postgres URL and restart `rune-api`.
+
+The migration CLI itself is still open as `rune#235`.
+
+## Licensing and Supply-Chain Rationale
+
+| Option | Decision | Rationale |
+|---|---|---|
+| PostgreSQL upstream | Approved | PostgreSQL License |
+| `docker.io/library/postgres:17-alpine` | Approved | Official image, minimal and well-understood supply chain |
+| `psycopg[binary]` / `psycopg[pure]` | Approved | Apache 2.0 wrapper around `libpq` |
+| First-party `rune-charts/charts/postgres` | Approved | Avoids third-party chart dependency |
+| CloudNativePG | Approved as BYO | Apache 2.0 HA path; not bundled |
+| Bitnami PostgreSQL chart | Rejected | Supply-chain and maintenance concerns after the Broadcom/Tanzu shift |
+| StackGres | Rejected | AGPLv3 |
+| Bundled MariaDB / MySQL server | Rejected | GPL server bundling concerns |
+| CockroachDB | Rejected | BUSL on current releases |
+
+If any exception is ever required, document it in the
+[VEX Register](../delivery/VEX.md) and in the relevant ADR or issue before
+changing the dependency set.
+
+## High Availability
+
+For the planned HA path, see [DATABASE_HA.md](DATABASE_HA.md).
+
+## Related References
+
+- [Configuration](../usage/CONFIGURATION.md)
+- [Developer Guide](../usage/DEVELOPER_GUIDE.md)
+- [Deployment](DEPLOYMENT.md)
+- [ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md)

--- a/docs/operations/DATABASE_HA.md
+++ b/docs/operations/DATABASE_HA.md
@@ -1,0 +1,132 @@
+# Database HA (CloudNativePG BYO)
+
+## Status
+
+This page describes the **planned high-availability PostgreSQL path** for
+RUNE. It is intentionally forward-looking:
+
+- CloudNativePG is the recommended operator for HA Postgres
+- RUNE's runtime integration with external PostgreSQL is **not fully released
+  yet**
+- Use this page for architecture and rollout planning, not as proof that HA DB
+  support is already generally available
+
+Track the remaining implementation work in:
+
+- `rune#233` — Postgres adapter
+- `rune#234` — `RUNE_DB_URL`
+- `rune-charts#71` — first-party Postgres subchart
+- `rune-docs#196` — final database ops guides
+
+## When You Need HA
+
+SQLite is enough when you have:
+
+- one `rune-api` replica
+- local development
+- a small single-node or single-pod deployment
+- no PITR or multi-AZ database requirement
+
+You should plan for HA PostgreSQL when you need:
+
+- multiple `rune-api` replicas sharing one store
+- higher write concurrency than an embedded SQLite file is comfortable with
+- defined RPO/RTO targets
+- managed backups and point-in-time recovery
+- stronger separation between application pods and persistence
+
+## Recommended HA Path
+
+RUNE's recommended HA database operator is **CloudNativePG (CNPG)**.
+
+Why CNPG:
+
+- Apache 2.0 license
+- CNCF ecosystem fit
+- PostgreSQL-native design
+- built-in backup and recovery workflows
+- avoids bundling a heavy HA operator into the default simple-install path
+
+## Why CNPG Is Not Bundled
+
+RUNE does **not** plan to bundle CNPG into the default deployment footprint
+because:
+
+- the simple case is still SQLite or a small Postgres install
+- bundling CNPG would significantly expand the default and airgapped footprint
+- many operators already have an approved HA Postgres platform
+
+The design is therefore:
+
+- bundle the lightweight first-party Postgres chart for simple external DB use
+- document CNPG as the bring-your-own HA path
+
+## CNPG Installation
+
+Example installation:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+helm install cnpg cloudnative-pg/cloudnative-pg \
+  --namespace cnpg-system \
+  --create-namespace
+```
+
+You would then create a CNPG-managed PostgreSQL cluster and expose the service
+name you want RUNE to use.
+
+## Planned RUNE Integration
+
+Once `RUNE_DB_URL` is released, the expected integration model will be a
+standard PostgreSQL connection string pointed at the CNPG primary service:
+
+```text
+postgresql://rune:${DB_PASSWORD}@rune-db-rw.rune.svc.cluster.local:5432/rune?sslmode=require
+```
+
+At the moment, this is a **target contract**, not a released runtime example.
+
+## Backups
+
+For HA PostgreSQL, prefer the operator-native backup path over hand-managed
+container scripts.
+
+With CNPG that generally means:
+
+- object-store-backed base backups
+- scheduled backups managed by the operator
+- retention policies defined at the cluster level
+
+## Point-In-Time Recovery
+
+CNPG supports PITR by restoring a cluster from base backup plus WAL archives.
+That is the recommended HA recovery story for RUNE once Postgres runtime support
+is fully released.
+
+Use PITR when you need:
+
+- recovery to a known timestamp before operator error
+- rollback after destructive data changes
+- stronger recovery objectives than file-level SQLite restore can provide
+
+## Practical Guidance For Today
+
+If you need RUNE **right now** and cannot wait for the remaining Postgres work:
+
+- run the current SQLite-backed deployment for single-pod installs
+- keep backups of the SQLite volume
+- do not deploy multiple `rune-api` replicas expecting shared persistence yet
+
+If you are designing a future production rollout:
+
+- standardize on PostgreSQL
+- prefer CloudNativePG for HA in Kubernetes
+- track `rune#233`, `rune#234`, and `rune-charts#71` before cutting over
+
+## Related References
+
+- [DATABASE.md](DATABASE.md)
+- [Deployment](DEPLOYMENT.md)
+- [Infrastructure](../architecture/INFRASTRUCTURE.md)
+- [ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md)

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -107,10 +107,21 @@ helm install rune ./charts/rune \
 ### Components
 
 - **rune-api**: Python API server handling jobs.
-- **SQLite**: Persistent volume for job storage.
+- **SQLite**: Current default persistence model. A single persistent volume backs
+  the embedded job store for local and single-pod installs.
 - **S3 Sink**: Results pushed to S3/SeaweedFS.
 - **rune-operator**: Cron-based job scheduling via Custom Resources.
 - **Vault**: Optional secret injection via **[Vault Agent](VAULT.md)**.
+
+### Storage Status
+
+Today, released deployments should assume **SQLite-only runtime support** via
+`RUNE_API_DB_PATH`.
+
+External PostgreSQL support is an accepted architecture direction, but it is not
+complete in the current release line. Track the design and rollout sequence in
+**[DATABASE.md](DATABASE.md)** and
+**[ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md)**.
 
  
 ## Infrastructure Dependencies

--- a/docs/operations/OBSERVABILITY.md
+++ b/docs/operations/OBSERVABILITY.md
@@ -53,6 +53,10 @@ All spans include `job_id` when executing within a job context. The `backend_typ
  
 ## Results Persistence
 
-- **SQLite**: Local/Kubernetes persistence for immediate job state.
+- **SQLite**: Current local/Kubernetes persistence for immediate job state.
 - **S3 Sink**: JSON results pushed to S3/SeaweedFS for long-term storage and audit.
   - Path: `results/{tenant}/{kind}/{date}/{job_id}.json`
+
+For the accepted but not yet fully released PostgreSQL storage direction, see
+[DATABASE.md](DATABASE.md) and
+[ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md).

--- a/docs/operations/ROLLBACK_PROCEDURES.md
+++ b/docs/operations/ROLLBACK_PROCEDURES.md
@@ -47,7 +47,11 @@ kubectl get pods -n rune -o jsonpath='{.items[*].spec.containers[*].image}'
 
 ## Database Schema Rollback
 
-RUNE uses SQLite for job persistence. The database file is stored in a persistent volume.
+RUNE currently uses SQLite for shipped job persistence. The database file is
+stored in a persistent volume.
+
+For the broader storage roadmap and the planned PostgreSQL path, see
+[DATABASE.md](DATABASE.md).
 
 ### Pre-upgrade Backup
 

--- a/docs/operations/RUNBOOKS.md
+++ b/docs/operations/RUNBOOKS.md
@@ -43,6 +43,10 @@ Incident response checklists for RUNE.
 2.  **K8s Volume Mount**: If in K8s, verify the PersistentVolume claim is `ReadWriteOnce` and not mounted by multiple pods.
 3.  **Restart**: Restarting the `rune-api` pod may resolve transient locks.
 
+This incident class is specific to the current SQLite-backed deployment model.
+For the planned external database direction, see
+[DATABASE.md](DATABASE.md) and [DATABASE_HA.md](DATABASE_HA.md).
+
  
 ## Incident Response
 

--- a/docs/usage/ADVANCED_PIPELINES.md
+++ b/docs/usage/ADVANCED_PIPELINES.md
@@ -1,0 +1,155 @@
+# Advanced Pipelines & Compliance Views
+
+RUNE exposes two run-scoped inspection surfaces for multi-agent and
+compliance-heavy workflows:
+
+| Surface | UI route | Backing API | Primary use |
+|---|---|---|---|
+| Chain DAG | `/chains/{run_id}` | `GET /v1/chains/{run_id}/state` | Visualize a multi-agent execution graph while it runs |
+| Audit artifacts | `/audits/{run_id}` | `GET /v1/audits/{run_id}/artifacts` | Browse and download compliance evidence for a run |
+
+These views are implemented in `rune-ui`, but they are thin shells around
+first-class `rune` API endpoints. The API contracts below are the stable
+integration points; the UI only renders them.
+
+## Chain DAG
+
+The chain page is a server-rendered HTML shell plus a zero-NPM, vanilla
+JavaScript SVG renderer. On first load, `rune-ui` pre-fetches chain state so
+the initial HTTP response reflects upstream success vs. unknown-run errors. The
+browser then refreshes the graph while the chain is still running.
+
+### What the page shows
+
+- Overall chain status (`pending`, `running`, `success`, `failed`, `skipped`)
+- Directed edges between chain steps
+- One node per agent step, labeled with `agent_name` when present
+- A detail panel with node status, start time, finish time, and error text
+- Manual **Refresh** and **Pause/Resume** controls
+
+### State contract
+
+`GET /v1/chains/{run_id}/state` returns a JSON document with this shape:
+
+```json
+{
+  "run_id": "chain-abc",
+  "overall_status": "running",
+  "nodes": [
+    {
+      "id": "draft",
+      "agent_name": "holmes",
+      "status": "success",
+      "started_at": 1712660000.0,
+      "finished_at": 1712660020.0,
+      "error": null
+    },
+    {
+      "id": "review",
+      "agent_name": "consensus",
+      "status": "running",
+      "started_at": 1712660021.0,
+      "finished_at": null,
+      "error": null
+    }
+  ],
+  "edges": [
+    {"from": "draft", "to": "review"}
+  ]
+}
+```
+
+Important behavior:
+
+- If the run exists but no chain state has been recorded yet, the API returns an
+  empty shell with `nodes: []`, `edges: []`, and `overall_status: "pending"`.
+- If the run is unknown or belongs to a different tenant, the API returns
+  `404`.
+- The UI keeps polling only while `overall_status` is `running`.
+
+## Audit Artifact Viewer
+
+The audit page is a static shell that fetches artifact metadata client-side and
+renders one card per artifact. Cards are grouped by `kind` and expose both
+inline previews and raw downloads.
+
+### Artifact kinds
+
+The current viewer recognizes these artifact kinds:
+
+- `slsa_provenance`
+- `sbom`
+- `tla_report`
+- `sigstore_bundle`
+- `rekor_entry`
+- `tpm_attestation`
+
+Inline previews are rendered for:
+
+- `slsa_provenance`
+- `sbom`
+- `tla_report`
+
+Binary or opaque artifacts such as Sigstore, Rekor, and TPM evidence are still
+listed, hashed, and downloadable, but they are not expanded inline.
+
+### Metadata contract
+
+`GET /v1/audits/{run_id}/artifacts` returns summary data plus one metadata entry
+per artifact:
+
+```json
+{
+  "run_id": "bench-123",
+  "summary": {
+    "total_count": 2,
+    "kinds_present": ["sbom", "slsa_provenance"]
+  },
+  "artifacts": [
+    {
+      "artifact_id": "aid-1",
+      "kind": "slsa_provenance",
+      "name": "provenance.json",
+      "size_bytes": 512,
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "created_at": 1712660100.0,
+      "download_url": "/v1/audits/bench-123/artifacts/aid-1"
+    }
+  ]
+}
+```
+
+The list endpoint intentionally omits raw bytes. Artifact content is retrieved
+via `GET /v1/audits/{run_id}/artifacts/{artifact_id}` and streamed with an
+attachment filename and content type.
+
+### Operational notes
+
+- An existing run with no audit evidence returns `200` with `artifacts: []`.
+- Unknown runs return `404`.
+- Audit artifact endpoints are tenant-scoped and require the same API auth as
+  the rest of `rune`.
+
+## How To Validate
+
+### Chain graph
+
+1. Start a run that records chain state.
+2. Open `/chains/{run_id}` in `rune-ui`.
+3. Confirm the SVG renders nodes and edges and that the status badge updates.
+4. Click a node and verify the detail panel populates with status/timestamps.
+
+### Audit evidence
+
+1. Start or select a run with recorded audit artifacts.
+2. Open `/audits/{run_id}` in `rune-ui`.
+3. Confirm the summary badge count matches the returned artifact list.
+4. Open inline previews for SLSA, SBOM, or TLA+ artifacts.
+5. Download at least one artifact and verify the filename and bytes match the
+   API response.
+
+## Related References
+
+- [API Specification](API_SPEC.md)
+- [Interfaces](INTERFACES.md)
+- [Deployment](../operations/DEPLOYMENT.md)

--- a/docs/usage/API_SPEC.md
+++ b/docs/usage/API_SPEC.md
@@ -85,6 +85,43 @@ Jobs are processed asynchronously. `POST` returns `202 Accepted` with a `job_id`
 `GET /v1/metrics/summary?job_id=<id>`
 - **Response**: `{"events": [...]}` (aggregated metrics)
 
+### Chain Visualization
+
+#### Get Chain State
+
+`GET /v1/chains/{run_id}/state`
+- **Response**: `{"run_id": "...", "nodes": [...], "edges": [...], "overall_status": "pending|running|success|failed|skipped"}`
+- **404**: Unknown run or tenant-scoped miss
+- **Notes**:
+  - Existing runs with no recorded chain state return an empty shell:
+    `{"run_id": "...", "nodes": [], "edges": [], "overall_status": "pending"}`
+  - `nodes[*]` include per-step status and timestamps; `edges[*]` use
+    `{"from": "...", "to": "..."}` pairs.
+
+### Audit Artifacts
+
+#### List Audit Artifacts
+
+`GET /v1/audits/{run_id}/artifacts`
+- **Response**:
+  `{"run_id": "...", "summary": {"total_count": 0, "kinds_present": []}, "artifacts": [...]}`
+- **Artifact metadata shape**:
+  `{"artifact_id": "...", "kind": "sbom", "name": "sbom.json", "size_bytes": 1234, "sha256": "...", "created_at": 1712660100.0, "download_url": "/v1/audits/{run_id}/artifacts/{artifact_id}"}`
+- **404**: Unknown run or tenant-scoped miss
+- **Notes**:
+  - The list response excludes raw bytes.
+  - An existing run with no audit evidence returns `200` with an empty list.
+
+#### Download Audit Artifact
+
+`GET /v1/audits/{run_id}/artifacts/{artifact_id}`
+- **Response**: Raw artifact bytes with `Content-Disposition: attachment`
+- **Content-Type**:
+  - `application/json` for JSON-backed artifacts such as SLSA provenance,
+    SBOMs, or TLA+ reports
+  - `application/octet-stream` for binary or opaque artifacts such as Sigstore,
+    Rekor, or TPM evidence
+
  
 ## Data Structures
 

--- a/docs/usage/CONFIGURATION.md
+++ b/docs/usage/CONFIGURATION.md
@@ -18,6 +18,13 @@ Environment variables and configuration files for RUNE.
 | `RUNE_API_TOKENS` | — | Comma-separated map of `tenant:token` for the server. |
 | `RUNE_API_AUTH_DISABLED` | `0` | Disable API authentication (dev-only). |
 
+`RUNE_API_DB_PATH` is the current released persistence knob. URL-based storage
+selection exists as an architectural direction, but `RUNE_DB_URL` is not yet a
+released runtime contract. See
+**[Database Operations](../operations/DATABASE.md)** and
+**[ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md)** for
+the planned PostgreSQL rollout.
+
 ### Driver Layer Configuration
 
 | Variable | Default | Description |

--- a/docs/usage/DEVELOPER_GUIDE.md
+++ b/docs/usage/DEVELOPER_GUIDE.md
@@ -285,7 +285,10 @@ kind delete cluster --name rune-test
 Before opening the PR, verify:
 
 - **API versions**: Did you change any request/response schema? Is it additive or breaking?
-- **Persistent data**: Did you change SQLite schemas or volume mount paths? Is there a migration path?
+- **Persistent data**: Did you change SQLite schemas, storage adapters, or
+  volume mount paths? Is there a migration path? Review
+  **[ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md)** if
+  the change touches persistence design.
 - **Cross-component contracts**: Did you change DriverTransport, AgentRunner, LLMBackend, or LLMResourceProvider protocols?
 - **Helm values**: Did you add/remove/rename any values.yaml keys?
 

--- a/docs/usage/INTERFACES.md
+++ b/docs/usage/INTERFACES.md
@@ -37,12 +37,14 @@ Run the server with `python -m rune.api`.
 
 ### Endpoints
 
-- `POST /v1/jobs/ollama`: Submit an Ollama provisioning job.
-- `POST /v1/jobs/agent`: Submit an agent analysis job.
+- `POST /v1/jobs/agentic-agent`: Submit an agent analysis job.
 - `POST /v1/jobs/benchmark`: Submit a full benchmark job.
+- `POST /v1/jobs/llm-instance`: Submit an LLM backend provisioning job.
+- `POST /v1/jobs/ollama-instance`: Deprecated alias for `llm-instance`.
 - `GET /v1/jobs/{job_id}`: Poll for job status and results.
-- `GET /v1/models/vastai`: List available Vast.ai models.
-- `GET /v1/models/ollama`: List models from a target Ollama server.
+- `GET /v1/catalog/vastai-models`: List available Vast.ai models.
+- `GET /v1/llm/models?backend_url=<url>&backend_type=ollama`: List models from a target backend.
+- `GET /v1/ollama/models?backend_url=<url>`: Deprecated alias for the backend-generic models endpoint.
 
 ### Auth Headers
 
@@ -54,6 +56,24 @@ Run the server with `python -m rune.api`.
 ## REST API Reference
 
 For a formal definition of all endpoints and request/reponse schemas, see the **[API Specification](API_SPEC.md)**.
+
+## Advanced Inspection Views
+
+These routes are primarily surfaced by `rune-ui`, but they are backed by
+first-class `rune` API contracts and are useful integration targets in their
+own right.
+
+| Surface | UI route | API route | Notes |
+|---|---|---|---|
+| Run detail | `/runs/{run_id}` | `GET /v1/jobs/{job_id}` | Status, result metadata, telemetry |
+| Live trace | `/runs/{run_id}` | `GET /api/v1/runs/{run_id}/trace` | UI proxy for the run event stream |
+| Browser live view | `/runs/{run_id}` | `GET /api/v1/runs/{run_id}/browser-stream` | UI proxy for browser screenshots |
+| Chain DAG | `/chains/{run_id}` | `GET /v1/chains/{run_id}/state` | Multi-agent graph state (`nodes`, `edges`, `overall_status`) |
+| Audit artifacts | `/audits/{run_id}` | `GET /v1/audits/{run_id}/artifacts` | Compliance evidence list grouped by artifact kind |
+| Audit download | `/audits/{run_id}` | `GET /v1/audits/{run_id}/artifacts/{artifact_id}` | Streams raw artifact bytes |
+
+See **[Advanced Pipelines](ADVANCED_PIPELINES.md)** for behavior and validation
+details.
 
  
 ## Wire Protocol (Driver Layer)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,5 @@
 site_name: RUNE Documentation
 site_description: Documentation for the RUNE platform, APIs, and compliance posture
-site_url: https://github.com/lpasquali/rune-docs
-repo_name: lpasquali/rune-docs
-repo_url: https://github.com/lpasquali/rune-docs
 theme:
   name: material
   palette:
@@ -57,6 +54,7 @@ nav:
       - Pricing & Access Tiers: usage/PRICING.md
       - Interfaces: usage/INTERFACES.md
       - API Specification: usage/API_SPEC.md
+      - Advanced Pipelines: usage/ADVANCED_PIPELINES.md
       - Configuration: usage/CONFIGURATION.md
       - LLM Backend Reference: usage/OLLAMA_REFERENCE.md
   - Delivery:
@@ -73,6 +71,8 @@ nav:
       - Workstation Setup: operations/WORKSTATION.md
       - Golden Image: operations/GOLDEN_IMAGE.md
       - Deployment: operations/DEPLOYMENT.md
+      - Database Operations: operations/DATABASE.md
+      - Database HA: operations/DATABASE_HA.md
       - Observability: operations/OBSERVABILITY.md
       - Runbooks: operations/RUNBOOKS.md
       - Rollback Procedures: operations/ROLLBACK_PROCEDURES.md
@@ -98,3 +98,4 @@ nav:
           - "0003: UI Design": architecture/adrs/0003-ui-design.md
           - "0004: Operator Parity": architecture/adrs/0004-operator-feature-parity.md
           - "0005: Advanced Cognitive Architecture": architecture/adrs/0005-advanced-cognitive-architecture.md
+          - "0006: Storage Abstraction and PostgreSQL": architecture/adrs/0006-storage-abstraction-postgres.md


### PR DESCRIPTION
Closes #175
Closes #196
Progresses #195

## Summary
- add an Advanced Pipelines guide for the shipped chain DAG and audit artifact views, and align the published API/interface docs with current `rune` and `rune-ui` behavior
- add ADR 0006 plus `DATABASE.md` and `DATABASE_HA.md` to document the SQLite vs PostgreSQL roadmap without overstating unreleased Postgres support
- remove MkDocs repo-host metadata so the published site no longer shows the top-right GitHub link or a configured hostname

## Acceptance Criteria Evidence
- `docs/usage/ADVANCED_PIPELINES.md` documents `/chains/{run_id}` and `/audits/{run_id}` with payload examples, validation steps, and artifact-kind coverage, which concludes the docs work behind `#175`
- `docs/operations/DATABASE.md` and `docs/operations/DATABASE_HA.md` cover the SQLite-vs-PostgreSQL decision matrix, planned connection-string formats, migration framework, backup/restore guidance, licensing rationale, and the CloudNativePG BYO HA path required by `#196`
- `docs/usage/CONFIGURATION.md`, `docs/usage/DEVELOPER_GUIDE.md`, `docs/operations/DEPLOYMENT.md`, `docs/architecture/INFRASTRUCTURE.md`, and `docs/architecture/adrs/0006-storage-abstraction-postgres.md` now distinguish the current SQLite reality from the accepted but not-yet-released PostgreSQL rollout, which progresses the broader epic in `#195`
- `mkdocs.yml`, `README.md`, and `docs/index.md` now surface the new pages in nav and remove the published-site GitHub header metadata

## Audit Checks
| Check | Result | Notes |
|---|---|---|
| Audit triggers | No triggers fired | Docs-only changes; no dependency, runtime, container, or workflow modifications |

## Breaking Changes
None. This PR changes documentation and site metadata only.

## Definition of Done
- [x] **Level 3** — documentation only

## Test plan
- [x] `./.venv/bin/mkdocs build --strict`
- [x] `./.venv/bin/pymarkdown scan docs mkdocs.yml README.md`
- [x] `git diff --check`