### PR TITLE
docs: external-projects section for rune-audit adopters (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ How to interact with and configure RUNE.
 - **[ADVANCED_PIPELINES](docs/usage/ADVANCED_PIPELINES.md)** — Chain DAG and audit artifact views.
 - **[CONFIGURATION](docs/usage/CONFIGURATION.md)** — Environment variables and files.
 
+## 🔭 External projects (rune-audit)
+
+- **[Overview](docs/external-projects/index.md)** — SR-2 adoption outside RUNE.
+- **[Quickstart](docs/external-projects/quickstart.md)** — Five-minute path to `sr2 verify`.
+
 ## 🚀 Delivery
 
 How RUNE is built, tested, and shipped.

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -46,6 +46,15 @@ stated in one bullet.
 
 **Read first** list now includes **[AUDIT_AGENTS.md](../delivery/AUDIT_AGENTS.md)**.
 
+### 2026-04-10 — External projects docs (rune-docs#232)
+
+New **`docs/external-projects/`** section for **rune-audit** adopters: overview,
+quickstart, configuration (`.rune-audit-project.yaml`), inspector library, custom
+inspectors (registry + current `run_all` limitation), requirement packs,
+CI samples (GitHub Actions reusable workflow, GitLab, Jenkins), and RUNE case
+study. **MkDocs** nav group **External projects (rune-audit)**; links from
+**`docs/index.md`** and repo **README**.
+
 ### 2026-04-09 — Advanced pipelines docs + database roadmap ADR
 
 **`ADVANCED_PIPELINES.md`** added to document the now-shipped chain DAG and

--- a/docs/external-projects/case-study-rune.md
+++ b/docs/external-projects/case-study-rune.md
@@ -1,0 +1,24 @@
+# Case study: RUNE program usage
+
+RUNE itself is a **multi-repo program** (`rune`, `rune-ui`, `rune-operator`, `rune-charts`, `rune-docs`, `rune-audit`, `rune-airgapped`, `rune-ci`). The same **SR-2 quantitative model** applies both **inside** RUNE and to **external** OSS adopters.
+
+## Documentation
+
+- **Normative SR-Q text**: **[Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md)** (this site).
+- **Operational audit agents** (legal/cyber narrative checks): **[Audit Agents](../delivery/AUDIT_AGENTS.md)**.
+- **Machine catalog**: implemented in **rune-audit** `rune_audit.sr2.catalog`.
+
+## Engineering workflow
+
+1. **rune-audit** ships the **`sr2`** Typer group (`verify`, `init`, `gaps`, `dashboard`, `config-validate`).
+2. **rune-ci** exposes **`sr2-compliance.yml`** so every consumer repo can call one workflow.
+3. **rune-docs** (this section) documents adoption for third parties; **rune-audit** keeps a one-page **[OSS_PROJECTS](https://github.com/lpasquali/rune-audit/blob/main/docs/OSS_PROJECTS.md)** pointer.
+
+## Stub phase transparency
+
+During early rollout, most inspectors return **`not_implemented`**. RUNE uses **non-strict** verification in informational jobs and reserves **strict** gates for repositories that have committed to full automation coverage.
+
+## Related epics
+
+- **rune-docs#208** — Generic OSS abstraction layer (parent of **#232**).
+- **rune-audit** issues **#211+** — concrete inspector implementations.

--- a/docs/external-projects/ci-integration.md
+++ b/docs/external-projects/ci-integration.md
@@ -1,0 +1,73 @@
+# CI integration examples
+
+## GitHub Actions (reusable workflow)
+
+The **rune-ci** repository publishes **`sr2-compliance.yml`**, a **`workflow_call`** job that:
+
+1. Checks out your repository.
+2. Checks out **lpasquali/rune-audit** at a configurable ref.
+3. Installs rune-audit with pip.
+4. Runs **`rune-audit sr2 verify .`** with optional **`--strict`**.
+
+**Caller example** (in `.github/workflows/sr2.yml`):
+
+```yaml
+name: SR-2
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  compliance:
+    uses: lpasquali/rune-ci/.github/workflows/sr2-compliance.yml@main
+    with:
+      strict: false
+      rune-audit-ref: main
+```
+
+Set **`strict: true`** when every SR-Q inspector you care about is implemented and must block merges.
+
+Inputs (see workflow source for the authoritative list):
+
+- **`python-version`** — default `3.14`
+- **`strict`** — maps to `sr2 verify --strict`
+- **`rune-audit-ref`** — branch/tag/SHA of rune-audit to install
+
+## GitLab CI
+
+```yaml
+stages: [compliance]
+
+sr2-verify:
+  stage: compliance
+  image: python:3.14-bookworm
+  script:
+    - git clone --depth 1 https://github.com/lpasquali/rune-audit.git /tmp/rune-audit
+    - python -m pip install /tmp/rune-audit
+    - rune-audit sr2 verify .
+```
+
+Add **`--strict`** to the last line when ready.
+
+## Jenkins (declarative sketch)
+
+```groovy
+stage('SR-2') {
+  steps {
+    sh '''
+      python -m pip install "git+https://github.com/lpasquali/rune-audit.git@main"
+      rune-audit sr2 verify .
+    '''
+  }
+}
+```
+
+## Secrets and provenance
+
+SR-2 **verify** is designed to run on **checked-out source** without cloud credentials. Keep tokens out of the verification step; use separate jobs for publish/deploy.
+
+## See also
+
+- [Quickstart](quickstart.md)
+- [CI_SHARED_WORKFLOWS.md](../delivery/CI_SHARED_WORKFLOWS.md) — how RUNE wires reusable workflows.

--- a/docs/external-projects/configuration.md
+++ b/docs/external-projects/configuration.md
@@ -1,0 +1,48 @@
+# Configuration reference
+
+## Project file: `.rune-audit-project.yaml`
+
+The on-disk schema is defined in **rune-audit** as `AuditProjectFile` in `rune_audit.sr2.project_config` (Pydantic). It describes **which repositories** belong to a logical project for future multi-repo scans.
+
+### Schema (v1)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `version` | int | yes | Must be `1` today. |
+| `name` | string | no | Human label (default `unnamed-project`). |
+| `repos` | list | no | Named repos to include. |
+
+Each **repo** entry:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Short id (e.g. `app`). |
+| `path` | string | Relative path from the project file (often `.`). |
+| `url` | string | Optional remote URL (metadata). |
+
+### Example
+
+```yaml
+# rune-audit external project definition (SR-2 / EPIC #227)
+version: 1
+name: my-oss-project
+repos:
+  - name: app
+    path: .
+```
+
+### CLI
+
+- **Generate**: `rune-audit sr2 init [-o path]`
+- **Validate**: `rune-audit sr2 config-validate .rune-audit-project.yaml`
+
+## Environment variables
+
+rune-audit historically uses the **`RUNE_AUDIT_*`** prefix for service configuration. For SR-2 CLI-only usage you typically need no extra env vars beyond Python/PATH.
+
+See rune-audit `README` and `rune_audit` package for collector-specific variables when you enable non-SR2 commands.
+
+## Related documentation
+
+- [Quickstart](quickstart.md)
+- [CI integration](ci-integration.md)

--- a/docs/external-projects/custom-inspectors.md
+++ b/docs/external-projects/custom-inspectors.md
@@ -1,0 +1,35 @@
+# Custom inspector guide
+
+## Extension point
+
+Implement **`InspectorFn`**:
+
+```python
+from rune_audit.sr2.inspectors import InspectContext
+from rune_audit.sr2.models import InspectResult, RequirementSpec
+
+def my_check(ctx: InspectContext, spec: RequirementSpec) -> InspectResult:
+    ...
+```
+
+Return a structured **`InspectResult`** with status **`pass`**, **`fail`**, **`not_applicable`**, or **`not_implemented`** (see `rune_audit.sr2.models`).
+
+## Registration
+
+**`InspectorRegistry`** (`rune_audit.sr2.registry`) maps requirement ids to callables via **`register()`**. Today **`run_all()`** always uses **`default_registry()`** internally, so the stock **`rune-audit sr2 verify`** CLI does not yet accept an injected registry. Custom inspectors require either:
+
+- extending rune-audit (fork or PR) to register callables on the default registry at import time, or  
+- waiting for **EPIC #228** / follow-on API work to pass a registry into **`run_verification`**.
+
+Until then, treat this section as the **intended** integration pattern.
+
+## Rules of thumb
+
+- One callable **per requirement id** you own; keep id strings aligned with **[Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md)**.
+- Prefer **pure** checks (read files under `ctx.root`, no network) for CI reproducibility.
+- Document evidence in your PR when adding a new inspector in a fork or upstream contribution.
+
+## Related
+
+- [Inspector library](inspector-library.md)
+- Upstream **EPIC #228** — pluggable inspector registry (rune-docs / rune-audit tracking).

--- a/docs/external-projects/index.md
+++ b/docs/external-projects/index.md
@@ -1,0 +1,25 @@
+# External projects (rune-audit)
+
+Use **[rune-audit](https://github.com/lpasquali/rune-audit)** on **non-RUNE** repositories to run the same **IEC 62443-4-1 ML4 SR-2** quantitative requirement catalog (SR-Q-001 … SR-Q-036) that RUNE tracks internally.
+
+These pages are the **adopter-facing** guide. The short upstream summary lives in the rune-audit repo as [`docs/OSS_PROJECTS.md`](https://github.com/lpasquali/rune-audit/blob/main/docs/OSS_PROJECTS.md).
+
+## In this section
+
+| Page | Purpose |
+| --- | --- |
+| [Quickstart](quickstart.md) | Install, init project file, first `sr2 verify` |
+| [Configuration](configuration.md) | `.rune-audit-project.yaml` schema |
+| [Inspector library](inspector-library.md) | Built-in vs stub inspectors, catalog |
+| [Custom inspectors](custom-inspectors.md) | `InspectorRegistry` extension |
+| [Requirement packs](requirement-packs.md) | Pack ids and SR-Q scope |
+| [CI integration](ci-integration.md) | GitHub Actions, GitLab, Jenkins patterns |
+| [Case study: RUNE](case-study-rune.md) | How the RUNE program consumes the same model |
+
+## Normative requirements text
+
+Requirement titles and evidence expectations are defined in **[Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md)** (rune-docs). Inspectors map evidence to those SR-Q ids.
+
+## Status
+
+Today many inspectors still return **`not_implemented`** (stub phase). Use `rune-audit sr2 verify` without `--strict` for informational runs; add `--strict` in CI when you are ready to fail on unfinished coverage.

--- a/docs/external-projects/inspector-library.md
+++ b/docs/external-projects/inspector-library.md
@@ -1,0 +1,37 @@
+# Inspector library reference
+
+## Catalog
+
+All **36** SR-Q requirements (**SR-Q-001** … **SR-Q-036**) are enumerated in rune-audit:
+
+- **Code**: `rune_audit.sr2.catalog.iter_requirements()`
+- **Priorities**: P0 / P1 / P2 aligned with **[Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md)**
+
+Use:
+
+```bash
+rune-audit sr2 verify . --priority P0
+```
+
+to scope runs while you incrementally implement inspectors.
+
+## Default registry
+
+`rune_audit.sr2.registry.default_registry()` returns an **`InspectorRegistry`** that maps requirement ids to callables. Until custom registrations exist, unknown ids resolve to **`stub_inspector`**, which yields **`not_implemented`** with a short detail string.
+
+## Standard inspectors
+
+Module **`rune_audit.sr2.standard_inspectors`** is the home for **built-in** checks as they land (see open issues in **rune-audit** for implementation status). The engine invokes the registry for each `RequirementSpec` from the catalog.
+
+## CLI introspection
+
+```bash
+rune-audit sr2 gaps              # list not_implemented
+rune-audit sr2 dashboard --format md
+rune-audit sr2 verify . --json   # full machine-readable report
+```
+
+## Further reading
+
+- [Custom inspectors](custom-inspectors.md)
+- [Requirement packs](requirement-packs.md)

--- a/docs/external-projects/quickstart.md
+++ b/docs/external-projects/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart (about five minutes)
+
+Goal: install **rune-audit**, create a project definition, and run **one** SR-2 verification pass on a repository.
+
+## Prerequisites
+
+- Python **3.12+** (3.14 used in shared CI workflows).
+- A git checkout of the **target** repository (your OSS app, not necessarily RUNE).
+
+## 1. Install rune-audit
+
+From a virtualenv:
+
+```bash
+python -m pip install "git+https://github.com/lpasquali/rune-audit.git@main"
+# or: pip install ./rune-audit   # when developing from a local clone
+```
+
+Confirm:
+
+```bash
+rune-audit --version
+```
+
+## 2. Create a project file
+
+At the **root of the repo you want to audit**:
+
+```bash
+cd /path/to/your/repo
+rune-audit sr2 init -o .rune-audit-project.yaml
+```
+
+This writes a starter file (see [Configuration](configuration.md)). Validate it:
+
+```bash
+rune-audit sr2 config-validate .rune-audit-project.yaml
+```
+
+## 3. Run verification
+
+Non-strict (typical while inspectors are still stubs):
+
+```bash
+rune-audit sr2 verify .
+```
+
+Strict CI gate (fails with exit code **2** if any inspector is still `not_implemented`):
+
+```bash
+rune-audit sr2 verify . --strict
+```
+
+Optional filters and output:
+
+```bash
+rune-audit sr2 verify . --priority P0
+rune-audit sr2 verify . --json
+rune-audit sr2 gaps --priority P0
+```
+
+## 4. Next steps
+
+- Add a reusable workflow: [CI integration](ci-integration.md).
+- Register real checks: [Custom inspectors](custom-inspectors.md).
+- Read the SR-Q catalog: [Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md).

--- a/docs/external-projects/requirement-packs.md
+++ b/docs/external-projects/requirement-packs.md
@@ -1,0 +1,20 @@
+# Requirement pack authoring
+
+## Built-in pack ids
+
+**`rune_audit.sr2.packs`** defines stable pack constants. Today the full **IEC 62443 SR-2** catalog is exposed as **`IEC_62443_SR2`**: all ids **`SR-Q-001`** … **`SR-Q-036`**.
+
+`ids_for_pack(pack_id)` is reserved for future named subsets (e.g. SLSA-only, CIS mapping). The parameter is accepted but currently returns the full SR-Q set.
+
+## Authoring new packs (future)
+
+Planned workflow (see **EPIC #229**):
+
+1. Declare a named pack as a **frozen set** of SR-Q ids.
+2. Wire **`rune-audit sr2 verify --pack <id>`** when the CLI gains pack filtering.
+3. Document evidence expectations per id in **[Quantitative security requirements](../architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md)**.
+
+## Related
+
+- [Inspector library](inspector-library.md)
+- [CI integration](ci-integration.md) — gate on `--priority` until `--pack` ships.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,13 @@ How to interact with and configure RUNE.
 - **[ADVANCED_PIPELINES](usage/ADVANCED_PIPELINES.md)** — Chain DAG and audit artifact views.
 - **[CONFIGURATION](usage/CONFIGURATION.md)** — Environment variables and files.
 
+## 🔭 External projects (rune-audit)
+
+Adopt SR-2 quantitative checks on **non-RUNE** repositories.
+
+- **[Overview](external-projects/index.md)** — Section hub and links.
+- **[Quickstart](external-projects/quickstart.md)** — Install, init, first verify.
+
 ## 🚀 Delivery
 
 How RUNE is built, tested, and shipped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,15 @@ nav:
       - Advanced Pipelines: usage/ADVANCED_PIPELINES.md
       - Configuration: usage/CONFIGURATION.md
       - LLM Backend Reference: usage/OLLAMA_REFERENCE.md
+  - External projects (rune-audit):
+      - Overview: external-projects/index.md
+      - Quickstart: external-projects/quickstart.md
+      - Configuration: external-projects/configuration.md
+      - Inspector library: external-projects/inspector-library.md
+      - Custom inspectors: external-projects/custom-inspectors.md
+      - Requirement packs: external-projects/requirement-packs.md
+      - CI integration: external-projects/ci-integration.md
+      - Case study — RUNE: external-projects/case-study-rune.md
   - Delivery:
       - Pipelines: delivery/PIPELINES.md
       - Shared CI Workflows: delivery/CI_SHARED_WORKFLOWS.md


### PR DESCRIPTION
## Summary

Add **`docs/external-projects/`** for rune-audit adoption outside RUNE: eight pages (overview, quickstart, configuration, inspector library, custom inspectors, requirement packs, CI integration, RUNE case study). Register in **MkDocs** nav, **`docs/index.md`**, and **README**. Update **CURRENT_STATE**.

Closes #232

Epic: #208

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] All documentation pages created — eight files under `docs/external-projects/` plus nav/README/index links.
- [x] Code examples — commands match current **`rune-audit`** CLI (`sr2 init`, `verify`, `config-validate`, `gaps`) and **`rune-ci`** `sr2-compliance.yml` inputs; custom-inspector section documents **`default_registry` / `run_all`** limitation honestly.
- [x] Linked from main README and docs hub — see **README.md** and **docs/index.md**.
- [x] Level 3 DoD — `mkdocs build --strict` and `pymarkdown scan` run locally (Python 3.14.4, repo `requirements.txt`).

## Test Plan Evidence

- [x] `mkdocs build --strict` (success)
- [x] `python -m pymarkdown scan README.md docs` (exit 0)
- [ ] Follow quickstart with fresh non-RUNE project — not executed in this agent session; reviewers can spot-check `pip install` + `sr2 verify` on a throwaway repo.

## Breaking Changes

None.

## Notes for Reviewer

- **QUANTITATIVE_SECURITY_REQUIREMENTS.md** remains out of MkDocs nav (pre-existing); external pages link to it by path.
- Optional follow-up: run quickstart end-to-end in CI or document a pinned rune-audit version for reproducibility.
