### PR TITLE
docs: SR2 external-projects — registry (#228), init & dashboard (#231 #212)

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -34,10 +34,10 @@ Last updated: **2026-04-10**.
 
 ### 2026-04-10 — External OSS: dashboard + init docs (rune-docs#212, #231)
 
-**External projects** [quickstart](external-projects/quickstart.md): document
+**External projects** [quickstart](../external-projects/quickstart.md): document
 **`rune-audit init`** (replacing incorrect `sr2 init` for bootstrap),
 **`rune-audit sr2 dashboard`** (HTML/JSON/Markdown, `--base-path`,
-`--previous` trend), and link **#212**. [Index](external-projects/index.md)
+`--previous` trend), and link **#212**. [Index](../external-projects/index.md)
 updated for stdlib **`not_applicable`** behavior and dashboard pointer.
 
 ### 2026-04-10 — SYSTEM_PROMPT compression

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -32,6 +32,14 @@ Last updated: **2026-04-10**.
  
 ## Recent Changes
 
+### 2026-04-10 — External OSS: dashboard + init docs (rune-docs#212, #231)
+
+**External projects** [quickstart](external-projects/quickstart.md): document
+**`rune-audit init`** (replacing incorrect `sr2 init` for bootstrap),
+**`rune-audit sr2 dashboard`** (HTML/JSON/Markdown, `--base-path`,
+`--previous` trend), and link **#212**. [Index](external-projects/index.md)
+updated for stdlib **`not_applicable`** behavior and dashboard pointer.
+
 ### 2026-04-10 — SYSTEM_PROMPT compression
 
 **`SYSTEM_PROMPT.md`** heavily shortened while keeping mandatory rules: core identity

--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -50,10 +50,16 @@ stated in one bullet.
 
 New **`docs/external-projects/`** section for **rune-audit** adopters: overview,
 quickstart, configuration (`.rune-audit-project.yaml`), inspector library, custom
-inspectors (registry + current `run_all` limitation), requirement packs,
+inspectors (registry / decorator patterns), requirement packs,
 CI samples (GitHub Actions reusable workflow, GitLab, Jenkins), and RUNE case
 study. **MkDocs** nav group **External projects (rune-audit)**; links from
 **`docs/index.md`** and repo **README**.
+
+### 2026-04-10 — Custom inspectors doc vs rune-audit #228
+
+**`external-projects/custom-inspectors.md`** aligned with **rune-audit**:
+`@register_inspector`, `default_registry()` + **`standard_inspectors`** import,
+and **`run_verification(..., registry=...)`** (stock CLI unchanged).
 
 ### 2026-04-09 — Advanced pipelines docs + database roadmap ADR
 

--- a/docs/external-projects/custom-inspectors.md
+++ b/docs/external-projects/custom-inspectors.md
@@ -16,12 +16,13 @@ Return a structured **`InspectResult`** with status **`pass`**, **`fail`**, **`n
 
 ## Registration
 
-**`InspectorRegistry`** (`rune_audit.sr2.registry`) maps requirement ids to callables via **`register()`**. Today **`run_all()`** always uses **`default_registry()`** internally, so the stock **`rune-audit sr2 verify`** CLI does not yet accept an injected registry. Custom inspectors require either:
+**`InspectorRegistry`** (`rune_audit.sr2.registry`) maps requirement ids to callables via **`register()`**.
 
-- extending rune-audit (fork or PR) to register callables on the default registry at import time, or  
-- waiting for **EPIC #228** / follow-on API work to pass a registry into **`run_verification`**.
+- **`@register_inspector("SR-Q-00N")`** — decorator registers a built-in when your module is imported before **`default_registry()`** runs (rune-audit ships **`standard_inspectors`** for this pattern).
+- **`default_registry()`** — builds a fresh registry, imports **`rune_audit.sr2.standard_inspectors`**, and applies all decorator-registered callables.
+- **`run_verification(..., registry=...)`** — library callers can pass a fully custom **`InspectorRegistry`** instance (wraps the same **`run_all(..., registry=...)`** path). The **`rune-audit sr2 verify`** CLI still uses the default registry only (no CLI flag yet).
 
-Until then, treat this section as the **intended** integration pattern.
+Forks and downstream packages can register via decorator in an importable module, or construct a registry in Python and call **`run_verification`** from their own entry point.
 
 ## Rules of thumb
 
@@ -32,4 +33,4 @@ Until then, treat this section as the **intended** integration pattern.
 ## Related
 
 - [Inspector library](inspector-library.md)
-- Upstream **EPIC #228** — pluggable inspector registry (rune-docs / rune-audit tracking).
+- **rune-docs#228** — pluggable inspector registry (registry API + engine wiring; CLI plugins remain follow-on).

--- a/docs/external-projects/index.md
+++ b/docs/external-projects/index.md
@@ -8,7 +8,7 @@ These pages are the **adopter-facing** guide. The short upstream summary lives i
 
 | Page | Purpose |
 | --- | --- |
-| [Quickstart](quickstart.md) | Install, init project file, first `sr2 verify` |
+| [Quickstart](quickstart.md) | Install, `rune-audit init`, `sr2 verify`, multi-repo `sr2 dashboard` |
 | [Configuration](configuration.md) | `.rune-audit-project.yaml` schema |
 | [Inspector library](inspector-library.md) | Built-in vs stub inspectors, catalog |
 | [Custom inspectors](custom-inspectors.md) | `InspectorRegistry` extension |
@@ -22,4 +22,6 @@ Requirement titles and evidence expectations are defined in **[Quantitative secu
 
 ## Status
 
-Today many inspectors still return **`not_implemented`** (stub phase). Use `rune-audit sr2 verify` without `--strict` for informational runs; add `--strict` in CI when you are ready to fail on unfinished coverage.
+Today many SR-Q rows still return **`not_implemented`** for catalog verification (stub phase). **Stdlib** inspectors (e.g. `stdlib.python_coverage`) return **`not_applicable`** when the technology is absent. Use `rune-audit sr2 verify` without `--strict` for informational runs; add `--strict` in CI when you are ready to fail on unfinished coverage.
+
+**Matrix dashboard:** `rune-audit sr2 dashboard` (HTML / JSON / Markdown) aggregates verification across repos listed in **`compliance-config.yaml`** — see [Quickstart §4](quickstart.md) and [rune-docs#212](https://github.com/lpasquali/rune-docs/issues/212).

--- a/docs/external-projects/quickstart.md
+++ b/docs/external-projects/quickstart.md
@@ -22,16 +22,17 @@ Confirm:
 rune-audit --version
 ```
 
-## 2. Create a project file
+## 2. Bootstrap config
 
 At the **root of the repo you want to audit**:
 
 ```bash
 cd /path/to/your/repo
-rune-audit sr2 init -o .rune-audit-project.yaml
+rune-audit init -y --org my-org --repos core --no-project-file
+# or interactive: rune-audit init
 ```
 
-This writes a starter file (see [Configuration](configuration.md)). Validate it:
+This writes **`compliance-config.yaml`** (and optionally **`.rune-audit-project.yaml`**). Validate the project file if you use it:
 
 ```bash
 rune-audit sr2 config-validate .rune-audit-project.yaml
@@ -59,7 +60,20 @@ rune-audit sr2 verify . --json
 rune-audit sr2 gaps --priority P0
 ```
 
-## 4. Next steps
+## 4. Multi-repo matrix dashboard (optional)
+
+From a **parent directory** that contains sibling clones named like your **`compliance-config.yaml`** `project.repos` entries:
+
+```bash
+cd ~/Devel
+rune-audit sr2 dashboard --base-path . --format html -o sr2-dashboard.html
+rune-audit sr2 dashboard --base-path . --format json -o sr2-dashboard.json
+rune-audit sr2 dashboard --single-repo --format md
+```
+
+Use **`--previous sr2-dashboard.json`** on a second run to emit a **trend delta** in HTML/JSON output. See [rune-docs#212](https://github.com/lpasquali/rune-docs/issues/212).
+
+## 5. Next steps
 
 - Add a reusable workflow: [CI integration](ci-integration.md).
 - Register real checks: [Custom inspectors](custom-inspectors.md).


### PR DESCRIPTION
## Summary

- Align **`external-projects/custom-inspectors.md`** with rune-audit **#228** API: decorator registration, **`default_registry()`**, and **`run_verification(..., registry=...)`**.
- **Quickstart** (`external-projects/quickstart.md`): root **`rune-audit init`** bootstrap, **`rune-audit sr2 dashboard`** (HTML / JSON / Markdown, `--base-path`, `--previous` trend), aligned with **#231** and **#212**.
- **Index** (`external-projects/index.md`): dashboard pointer, stdlib **`not_applicable`** note.
- **`CURRENT_STATE`** entry for the above.

Refs #228
Refs #212
Refs #231

Epic: #208

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Doc reflects current rune-audit integration paths (see **lpasquali/rune-audit** PR **[#82](https://github.com/lpasquali/rune-audit/pull/82)** — epic branch; registry wiring may also land via **#81** / **#228** as applicable).
- [x] Quickstart covers **`init`** and **`sr2 dashboard`** per **#231** / **#212**.

## Test Plan Evidence

- [x] `mkdocs build --strict`
- [x] `pymarkdown scan README.md docs`

## Breaking Changes

None.

## Notes for Reviewer

- **Do not auto-close #228** from this PR if the rune-audit PR uses **`Closes lpasquali/rune-docs#228`** — prefer merging **rune-audit** first where cross-linked.
- Implementation for **#212**, **#227–#231**: **lpasquali/rune-audit** [**PR #82**](https://github.com/lpasquali/rune-audit/pull/82).
