### PR TITLE
docs: CURRENT_STATE — .claude/ gitignore sweep

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -32,6 +32,11 @@ Last updated: **2026-04-10**.
  
 ## Recent Changes
 
+### 2026-04-10 — `.claude/` in `.gitignore` (rune-docs#199, rune#250)
+
+All eight RUNE repos ignore **`.claude/`** (Claude Code local state). **rune** was the last
+gap; **rune#250** merged the line to **`main`**. Tracking issue **rune-docs#199** closed.
+
 ### 2026-04-10 — RuneBenchmark budget gate (rune-operator#94, rune-charts#77)
 
 **rune-operator** `main` adds optional **`spec.budget.maxCostUSD`**: before job submit, GET


### PR DESCRIPTION
## Summary

Adds a **Recent Changes** line in **CURRENT_STATE.md** recording completion of the **`.claude/`** `.gitignore` sweep (**rune-docs#199**, **rune#250**).

Closes: n/a
Epic: n/a

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

*Skipped (Level 3).*

## Level 2 Checklist

*Skipped (Level 3).*

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes (CI MarkdownLint equivalent)

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(docs-only)* | — | Markdown edit to `CURRENT_STATE.md` only |

## Acceptance Criteria Evidence

- [x] **CURRENT_STATE** — New subsection under Recent Changes documents **rune#250** + **#199** closure.

## Test Plan Evidence

- [x] Local `mkdocs build --strict` on branch before push.

## Breaking Changes

None.

## Notes for Reviewer

None.
