### PR TITLE
docs(context): CURRENT_STATE — project backfill github-script fix

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -36,6 +36,17 @@ Last updated: **2026-04-11**.
 
 **Python** repos now use the same **standalone** \`.github/workflows/codeql.yml\` as **rune** (PR/push/weekly, pinned \`codeql-action\`, \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\`). Merged: **rune-ui#122**, **rune-docs#245**, **rune-charts#79**, **rune-airgapped#69** (inline, no \`rune-ci\` caller), **rune-audit#86**. Where **CodeQL default setup** had been enabled (**rune-ui**, **rune-charts**, **rune-audit**), it was set to \`not-configured\` so advanced SARIF upload works (see issues **#121**, **#78**, **#85**).
 
+### 2026-04-11 — Project board backfill: `github-script` duplicate `core` (rune-ci)
+
+**Scheduled Project Board Backfill** failed with `SyntaxError: Identifier 'core' has already been declared`
+because **`actions/github-script` v8** already injects **`core`** into the script scope; reusable workflow
+**`project-backfill-logic.yml`** in **rune-ci** also declared `const core = require('@actions/core')`.
+**rune-ci** `main` commit **`8cae0c5`** removes the redundant line.
+
+**Evidence:** `workflow_dispatch` **Project Board Backfill** on **rune-docs** completed successfully after the fix:
+https://github.com/lpasquali/rune-docs/actions/runs/24277613301 (prior failure:
+https://github.com/lpasquali/rune-docs/actions/runs/24276942219/job/70892417613). Consumer repos call the workflow at **`@main`** — no pin bump required.
+
 ### 2026-04-10 — `.claude/` in `.gitignore` (rune-docs#199, rune#250)
 
 All eight RUNE repos ignore **`.claude/`** (Claude Code local state). **rune** was the last


### PR DESCRIPTION
## Summary

Update **CURRENT_STATE.md** with the **project-backfill** failure root cause, **rune-ci** fix commit, and verification links for **SOP Step 9 / atomic persistence** after CI work.

Closes #242

Epic: (none)

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

N/A (Level 3).

## Level 2 Checklist

N/A (Level 3).

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired. (Markdown-only `CURRENT_STATE.md` update; no dependency, workflow, API, Dockerfile, or Helm changes.)

## Acceptance Criteria Evidence

- [x] **CURRENT_STATE** reflects the **rune-ci** fix and verification — evidence: diff in this PR; links in issue #242 and in **Recent Changes** entry.

## Test Plan Evidence

- [x] `mkdocs build --strict` (local): PASS
- [x] `pymarkdown scan README.md docs` (local): PASS
- [x] **Project Board Backfill** `workflow_dispatch` after **rune-ci** fix: https://github.com/lpasquali/rune-docs/actions/runs/24277613301

## Breaking Changes

None.

## Notes for Reviewer

**rune-ci** change is already on **`main`** (`8cae0c5`). This PR is documentation / SSOT persistence only.
