### PR TITLE
chore(ci): adopt rune-ci@eae1383 merge gate policy

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,23 +16,15 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
 
   docs:
-    uses: lpasquali/rune-ci/.github/workflows/docs-quality.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/docs-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
 
   compliance:
     needs: [security, docs]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "docs,security" # Force pass
-
-  merge-gate:
-    name: Merge Gate
-    needs: [compliance]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Merge Gate Satisfied"

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b
 
   docs:
-    uses: lpasquali/rune-ci/.github/workflows/docs-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
+    uses: lpasquali/rune-ci/.github/workflows/docs-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b
 
   compliance:
     needs: [security, docs]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "docs,security" # Force pass


### PR DESCRIPTION
## Summary

Pins `lpasquali/rune-ci` reusable workflows to `eae13830420fe3b9d558edb081c01c90bdc01d03` and removes the redundant top-level `merge-gate` job so the **Merge Gate** enforced inside `pr-compliance` is authoritative (SoD / epic https://github.com/lpasquali/rune-ci/issues/25).

Fixes #255

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes (via Quality Gates on this PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects (workflow-only change)

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| (n/a) | PASS | No audit triggers per SYSTEM_PROMPT |

## Acceptance Criteria Evidence

- [x] Workflow pins and merge-gate wiring match SoD follow-up issue — evidence: this PR diff and green Quality Gates.

## Test Plan Evidence

- [x] CI-only change; validated by repository Quality Gates workflow on this PR.

## Breaking Changes

None.

## Notes for Reviewer

Part of SoD remediation after unreviewed `rune-ci` `main` push (retro https://github.com/lpasquali/rune-ci/issues/26).
