### PR TITLE
docs: align ADR 0006 and DATABASE guides with production airgap model

### DIFF
--- a/docs/architecture/adrs/0006-storage-abstraction-postgres.md
+++ b/docs/architecture/adrs/0006-storage-abstraction-postgres.md
@@ -49,13 +49,27 @@ RUNE will support two storage backends behind the same storage interface:
 
 ### Deployment
 
-- The simple packaged Postgres path is a **first-party Helm subchart** in
-  `rune-charts`, wrapping the official `docker.io/library/postgres:17-alpine`
-  image.
-- High-availability PostgreSQL is documented as **BYO CloudNativePG**, not a
-  bundled dependency.
-- The airgapped bundle will include the approved Postgres image once the chart
-  and runtime support are ready.
+#### Development / Local Deployments
+- SQLite remains the default; no database provisioning needed.
+- In-cluster Postgres (via optional `rune-charts/postgres` subchart) is
+  available for development and lab environments that need a managed database.
+- The subchart wraps the official `docker.io/library/postgres:17-alpine` image.
+
+#### Production Airgapped Deployments (Tier 1 — Recommended)
+- **PostgreSQL is a customer-managed prerequisite**, not bundled.
+- Customers provision PostgreSQL externally: CloudNativePG operator, AWS RDS,
+  Cloud SQL, or other managed services.
+- RUNE configures the database via `RUNE_DB_URL` Secret.
+- The OCI bundle ships RUNE suite images only; no embedded Postgres image.
+- This model aligns with production airgapped practices: all external services
+  (database, storage, inference) are customer-operated prerequisites.
+
+#### High-Availability PostgreSQL
+- **HA PostgreSQL is documented as BYO CloudNativePG** or equivalent operator,
+  not a bundled dependency.
+- CNPG (CloudNativePG) is the recommended Kubernetes-native option for HA.
+- Managed services (AWS RDS Multi-AZ, Cloud SQL HA) are production-ready
+  alternatives when available in the deployment environment.
 
 ## Licensing and Supply-Chain Constraints
 
@@ -75,7 +89,7 @@ no-proprietary / no-fragile-supply-chain rules.
 
 ## Implementation Status
 
-As of **2026-04-09**:
+As of **2026-04-16**:
 
 - Done:
   - `rune#231` — `StoragePort` extraction and `SQLiteStorageAdapter`
@@ -86,19 +100,36 @@ As of **2026-04-09**:
   - `rune#235` — `rune db migrate-to-postgres`
   - `rune#236` — Postgres integration test matrix
   - `rune-charts#71` — first-party Postgres subchart
-  - `rune-airgapped#63` — bundle Postgres image
+  - `rune-charts#82` — Helm airgapped production values (external services)
+  - `rune-airgapped#72` — make Postgres opt-in in OCI bundle
+  - `rune-airgapped#73` — prerequisites matrix (external DB, S3, inference)
   - `rune-docs#196` — end-user database operations guides
+  - `rune-docs#253` — align DATABASE*.md with production airgap model (THIS ADR)
 
-This ADR intentionally lands before the final operations guides. The operator
-runbooks, connection-string reference, and HA procedures should only be written
-once the runtime config and Helm story exist in released code.
+### Airgapped Deployment Model (Epic #252)
+
+The production airgapped deployment model treats PostgreSQL, S3, and inference
+backends as **customer-managed prerequisites** (not bundled). This is reflected in:
+
+- `rune-airgapped#72`: OCI bundle ships RUNE-suite-only; `--include-postgres` is
+  opt-in for dev/lab.
+- `rune-airgapped#73`: Prerequisites matrix documents external DB, S3, inference
+  setup examples.
+- `rune-charts#82`: Production Helm values reference external services via Secrets.
+- This ADR section **Deployment**: Clarifies production airgap uses external Postgres.
+- `rune-docs#196`: Database operations guides to document production path.
 
 ## Consequences
 
-- Existing SQLite users keep a stable default path and do not need to migrate
-  immediately.
-- The storage interface becomes the boundary for future persistence changes.
-- The eventual Postgres rollout can be documented and tested without rewriting
-  application code again.
-- Until `rune#234` lands, public docs must clearly state that external Postgres
-  support is a planned capability rather than a released one.
+- **SQLite users**: Remain on stable default path; no forced migration.
+- **Development users**: Optional in-cluster Postgres via Helm subchart.
+- **Production airgapped users**: PostgreSQL is a customer-managed prerequisite,
+  provisioned out-of-band. The OCI bundle ships RUNE-suite-only; all external
+  services (database, S3, inference) are customer-operated.
+- **Storage interface**: Becomes the boundary for future persistence changes.
+- **HA users**: CNPG operator or equivalent is the recommended Kubernetes-native
+  path for high-availability PostgreSQL.
+- **Documentation**: Must clearly distinguish between development (SQLite default,
+  optional in-cluster Postgres) and production (external Postgres, prerequisite).
+- **Airgapped deployments**: The bundle never bundles data-plane services;
+  external services are required prerequisites documented in deployment guides.

--- a/docs/operations/DATABASE.md
+++ b/docs/operations/DATABASE.md
@@ -3,29 +3,31 @@
 ## Status
 
 **Current release status:** RUNE ships with **SQLite** as the supported runtime
-store today.
+store for local development and single-pod deployments.
 
-External PostgreSQL support is an accepted direction and parts of the storage
-refactor are already merged, but the Postgres adapter, runtime selection, Helm
-subchart, and migration CLI are **not all released yet**. This page therefore
-documents both:
+**Production deployments** (especially airgapped) require **external PostgreSQL**
+as a customer-managed prerequisite. Parts of the storage refactor are already
+merged, but the Postgres adapter, runtime selection, and migration CLI are
+**not all released yet**. This page therefore documents:
 
-- what is **supported now**
-- what is the **planned operational model** once the remaining work lands
+- what is **supported now** (SQLite for dev/lab)
+- what is the **planned production model** (external PostgreSQL)
+- deployment patterns for **production airgapped** environments
 
 Track implementation status in
 [ADR 0006](../architecture/adrs/0006-storage-abstraction-postgres.md).
 
 ## Decision Matrix
 
-| Deployment shape | Recommended store | Status today | Why |
+| Deployment shape | Recommended store | Status | Why |
 |---|---|---|---|
 | Local development | SQLite | Supported | Lowest friction, no extra service |
-| Single-pod Kubernetes | SQLite | Supported | Embedded persistence is sufficient |
-| Simple airgapped install | SQLite | Supported | Fewer moving parts and smaller bundle |
+| Single-pod Kubernetes (dev/lab) | SQLite | Supported | Embedded persistence is sufficient |
+| Lab airgapped (optional Postgres) | SQLite or in-cluster Postgres | Supported | Bundle includes Postgres image (opt-in with `--include-postgres`) |
+| **Production airgapped (RECOMMENDED)** | **External PostgreSQL** | **Planned (design ready)** | **Customer-managed prerequisite; CNPG operator or managed DB** |
 | Multi-pod `rune-api` deployment | PostgreSQL | Planned | Shared network database for multiple replicas |
-| Audit-heavy / compliance-focused production | PostgreSQL | Planned | Centralized persistence and cleaner separation from app pods |
-| HA / multi-AZ / PITR requirements | PostgreSQL + CNPG | Planned | SQLite is not the right HA substrate |
+| Compliance-focused production | PostgreSQL | Planned | Centralized persistence, audit trail, separation from app pods |
+| HA / multi-AZ / PITR requirements | PostgreSQL + CNPG | Planned | SQLite is not the right HA substrate; CNPG recommended |
 
 ## Current Supported Configuration
 


### PR DESCRIPTION
## Summary

Production air-gapped deployments use external PostgreSQL (not bundled). This PR updates ADR 0006 and database operations guides to document the production airgapped model clearly.

Closes #253
Epic: #252

## DoD Level

- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] ADR 0006: Production airgap section clarifies external PostgreSQL
  - Evidence: New "Deployment" sections added with clear dev vs. production vs. HA paths
- [x] ADR 0006: Links to epic #252 child issues documented
  - Evidence: Implementation Status section updated with references to rune-airgapped#72, #73, rune-charts#82, rune-docs#253
- [x] DATABASE.md: Status section prioritizes production airgap path
  - Evidence: Updated "Status" section to emphasize external PostgreSQL for production
- [x] DATABASE.md: Decision matrix shows "Production airgapped (RECOMMENDED)"
  - Evidence: Decision matrix includes new "Production airgapped (RECOMMENDED)" row with external PostgreSQL
- [x] Documentation distinguishes dev (SQLite), lab (optional Postgres), production (external)
  - Evidence: All three paths documented with clear examples and rationale
- [x] mkdocs build --strict passes
  - Evidence: Documentation builds without warnings or errors

## Test Plan Evidence

- [x] mkdocs build --strict: All docs build successfully
- [x] Markdown lint: No formatting issues
- [x] Cross-reference validation: Links to ADR, issue numbers, and related docs all correct
- [x] Content accuracy: All three deployment paths (dev, lab, production) properly documented

## Breaking Changes

None. This is documentation update that clarifies existing design direction.

## Notes for Reviewer

This completes the documentation alignment for production airgapped deployments (epic #252). Key updates:

**ADR 0006** now clearly states:
- Production airgap uses external PostgreSQL (customer-managed prerequisite)
- OCI bundle ships RUNE-suite-only (no embedded Postgres)
- CNPG operator recommended for Kubernetes HA

**DATABASE.md** decision matrix now includes:
- Lab airgapped path (optional in-cluster Postgres)
- Production airgapped path (external PostgreSQL, RECOMMENDED)
- HA requirements (PostgreSQL + CNPG)

Pairs with rune-airgapped#72 (Postgres opt-in), rune-airgapped#73 (prerequisites), rune-charts#82 (Helm values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)