### PR TITLE
docs(index): persona-routed landing page — mission + 90s pitch + 6 personas

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,56 +1,118 @@
-# RUNE Documentation Hub
+# RUNE Documentation
 
-Welcome to the central documentation for the RUNE platform.
+**RUNE** (Reliability Use-case Numeric Evaluator) is an **agent-neutral, backend-neutral benchmarking and compute-provisioning platform** for AI agents — so that SREs, researchers, and regulated-industry teams can compare heterogeneous agents on reproducible, cost-controlled workloads.
 
-## 🤖 Context (AI Memory)
+RUNE runs 23+ agents across five scopes (SRE, Research, Cybersecurity, Legal/Ops, Art/Creative) with pluggable LLM backends and optional cloud-GPU provisioning. No agent and no backend is privileged in code — defaults live in `rune.yaml`, never hardcoded. Cost gates are **fail-closed** (GPU provisioning rejected when `confidence_score < 0.95`; local-only workflows skip gates). Releases carry SLSA L3-style provenance and are built to an IEC 62443-4-1 **ML4** process.
 
-Instructions, state, and rules for LLMs and agents.
+Pre-alpha today (`v0.0.0a5`) — API surfaces are not stable. See [CURRENT_STATE](context/CURRENT_STATE.md) for version-to-version status until a human-readable changelog lands under [epic #273](https://github.com/lpasquali/rune-docs/issues/273) child [#283](https://github.com/lpasquali/rune-docs/issues/283).
 
-- **[SYSTEM_PROMPT](context/SYSTEM_PROMPT.md)** — Core identity and constraints.
-- **[CURRENT_STATE](context/CURRENT_STATE.md)** — Living memory, WIP, and next steps.
-- **[CODING_STANDARDS](context/CODING_STANDARDS.md)** — Specific stylistic rules.
+## Start here
 
-## 📖 Usage
+Pick the card that matches your goal — each links to the page you should read first.
+
+### Evaluator
+
+I want to try RUNE in 10 minutes.
+
+→ **[Quickstart](usage/QUICKSTART.md)** — three parallel paths: pip-CLI (5 min), docker-compose (10 min), kind + helm (15 min).
+
+### Operator
+
+I want to deploy RUNE in production — on-prem or on a cloud.
+
+→ **[Deployment](operations/DEPLOYMENT.md)** — hosting modes + per-cloud install guides (on-prem / AWS / GCP / Azure / Alibaba Cloud, landing under `operations/INSTALL_*` as part of [#277](https://github.com/lpasquali/rune-docs/issues/277)). Observability, rollback, and runbooks all live under the [Operations](#operations) section below.
+
+### Developer
+
+I want to build against the API or extend RUNE with a new driver, backend, or agent.
+
+→ **[Developer Guide](usage/DEVELOPER_GUIDE.md)** + **[API Specification](usage/API_SPEC.md)** + **[Interfaces](usage/INTERFACES.md)**. For the underlying extension protocols, see [SYSTEM_PROMPT §Extension points](context/SYSTEM_PROMPT.md#extension-points-protocols).
+
+### Agent author
+
+I want to ship a custom agent that plugs into RUNE via the `DriverTransport` protocol.
+
+→ **Agents SDK** (new section landing under `agents/` as part of [epic #273](https://github.com/lpasquali/rune-docs/issues/273) child [#280](https://github.com/lpasquali/rune-docs/issues/280)). Until then: read [SYSTEM_PROMPT §Extension points](context/SYSTEM_PROMPT.md#extension-points-protocols) and [CODING_STANDARDS §Agent filesystem layout](context/CODING_STANDARDS.md).
+
+### Compliance
+
+I need to understand RUNE's regulatory and supply-chain posture.
+
+→ **Compliance matrix** (new section landing under `compliance/` as part of [epic #273](https://github.com/lpasquali/rune-docs/issues/273) child [#282](https://github.com/lpasquali/rune-docs/issues/282)). Until then: [Security](#security) section below, [VEX Register](delivery/VEX.md), [Audit Agents](delivery/AUDIT_AGENTS.md).
+
+### Adopter
+
+I want to use a RUNE component standalone (rune-audit, rune-operator, rune-ui, rune-airgapped, or the driver SDK).
+
+→ **[External projects](external-projects/index.md)** — currently the landing for rune-audit; sibling pages for rune-operator / rune-ui / rune-airgapped / driver-sdk are landing under child [#279](https://github.com/lpasquali/rune-docs/issues/279).
+
+## Full documentation map
+
+For readers who prefer the full outline over persona routing:
+
+### Context
+
+Instructions, state, and rules for agents and humans onboarding to the codebase.
+
+- **[SYSTEM_PROMPT](context/SYSTEM_PROMPT.md)** — core identity, mandates, SOP.
+- **[CURRENT_STATE](context/CURRENT_STATE.md)** — living memory, WIP, known issues.
+- **[CODING_STANDARDS](context/CODING_STANDARDS.md)** — style, coverage floors, tier layout.
+
+### Usage
 
 How to interact with and configure RUNE.
 
-- **[QUICKSTART](usage/QUICKSTART.md)** — Getting started locally.
-- **[INTERFACES](usage/INTERFACES.md)** — CLI commands and API endpoints.
-- **[ADVANCED_PIPELINES](usage/ADVANCED_PIPELINES.md)** — Chain DAG and audit artifact views.
-- **[CONFIGURATION](usage/CONFIGURATION.md)** — Environment variables and files.
+- **[Quickstart](usage/QUICKSTART.md)** — getting started locally.
+- **[Developer Guide](usage/DEVELOPER_GUIDE.md)** — repos, env, build/test/lint, DoD validation.
+- **[Guide](usage/GUIDE.md)** — end-to-end walkthrough.
+- **[Pricing & Access Tiers](usage/PRICING.md)** — tier 1/2/3 cost implications.
+- **[Interfaces](usage/INTERFACES.md)** — CLI commands and API endpoints.
+- **[API Specification](usage/API_SPEC.md)** — REST API reference.
+- **[Advanced Pipelines](usage/ADVANCED_PIPELINES.md)** — chain DAG + audit artifact views.
+- **[Configuration](usage/CONFIGURATION.md)** — environment variables and `rune.yaml`.
+- **[LLM Backend Reference](usage/OLLAMA_REFERENCE.md)** — backend API surface.
 
-## 🔭 External projects (rune-audit)
+### External projects
 
-Adopt SR-2 quantitative checks on **non-RUNE** repositories.
+Adopt RUNE components on **non-RUNE** codebases. Currently populated for rune-audit.
 
-- **[Overview](external-projects/index.md)** — Section hub and links.
-- **[Quickstart](external-projects/quickstart.md)** — Install, init, first verify.
+- **[Overview](external-projects/index.md)**, [Quickstart](external-projects/quickstart.md), [Configuration](external-projects/configuration.md), [Inspector library](external-projects/inspector-library.md), [Custom inspectors](external-projects/custom-inspectors.md), [Requirement packs](external-projects/requirement-packs.md), [CI integration](external-projects/ci-integration.md), [Case study — RUNE](external-projects/case-study-rune.md).
 
-## 🚀 Delivery
+### Delivery
 
 How RUNE is built, tested, and shipped.
 
-- **[PIPELINES](delivery/PIPELINES.md)** — CI/CD and automated testing.
-- **[RELEASES](delivery/RELEASES.md)** — Versioning and artifact publishing.
-- **[SECRETS](delivery/SECRETS.md)** — Security and compliance policy.
+- **[Pipelines](delivery/PIPELINES.md)**, [Shared CI Workflows](delivery/CI_SHARED_WORKFLOWS.md), [CI Migration Risk Mitigations](delivery/CI_RISK_MITIGATIONS.md), [Releases](delivery/RELEASES.md), [Secrets](delivery/SECRETS.md), [VEX Register](delivery/VEX.md), [Milestones](delivery/MILESTONES.md), [Labels](delivery/LABELS.md), [Audit Agents](delivery/AUDIT_AGENTS.md).
 
-## ⚙️ Operations
+### Operations
 
 How RUNE is hosted and maintained.
 
-- **[DEPLOYMENT](operations/DEPLOYMENT.md)** — Hosting modes and provisioning.
-- **[DATABASE](operations/DATABASE.md)** — Current SQLite operations and planned PostgreSQL rollout.
-- **[OBSERVABILITY](operations/OBSERVABILITY.md)** — Metrics and logging.
-- **[RUNBOOKS](operations/RUNBOOKS.md)** — Incident response checklists.
+- **[Workstation Setup](operations/WORKSTATION.md)** — development machine provisioning.
+- **[Golden Image](operations/GOLDEN_IMAGE.md)** — automated provisioning across 30+ platforms.
+- **[Deployment](operations/DEPLOYMENT.md)** — hosting modes (CLI / compose / kind / k8s-prod).
+- **[Database Operations](operations/DATABASE.md)** + **[Database HA](operations/DATABASE_HA.md)** — SQLite today, PostgreSQL planned.
+- **[Observability](operations/OBSERVABILITY.md)** — metrics and logging.
+- **[Runbooks](operations/RUNBOOKS.md)** — incident response checklists.
+- **[Rollback Procedures](operations/ROLLBACK_PROCEDURES.md)** — version, chart, and DB rollback.
+- **[Vault Integration](operations/VAULT.md)** — secret injection.
 
-## 🏗️ Architecture
+### Security
+
+RUNE's security posture, programme, and evidence.
+
+- **[Security Development Lifecycle](security/SDL.md)**, [Risk Assessment Methodology](security/RISK_ASSESSMENT.md), [Risk Register](security/RISK_REGISTER.md), [Penetration Testing](security/PENTEST.md), [Fuzz Testing](security/FUZZ_TESTING.md), [Incident Response](security/INCIDENT_RESPONSE.md), [Container Image Signing](security/IMAGE_SIGNING.md), [Security Training Records](security/SECURITY_TRAINING.md).
+
+### Architecture
 
 How RUNE is designed internally.
 
-- **[SYSTEM_DESIGN](architecture/SYSTEM_DESIGN.md)** — Component diagrams and layout.
-- **[INFRASTRUCTURE](architecture/INFRASTRUCTURE.md)** — Networking and dependencies.
-- **[ADRs](architecture/adrs/0001-api-compatibility.md)** — Architecture Decision Records.
+- **[Threat Model](architecture/THREAT_MODEL.md)**, [Security Requirements](architecture/SECURITY_REQUIREMENTS.md), [System Design](architecture/SYSTEM_DESIGN.md), [Infrastructure](architecture/INFRASTRUCTURE.md), [Formal Specs](architecture/FORMAL_SPECS.md).
+- **ADRs** — [0001 API Compatibility](architecture/adrs/0001-api-compatibility.md) · [0002 Cost Estimation](architecture/adrs/0002-cost-estimation.md) · [0003 UI Design](architecture/adrs/0003-ui-design.md) · [0004 Operator Parity](architecture/adrs/0004-operator-feature-parity.md) · [0005 Advanced Cognitive Architecture](architecture/adrs/0005-advanced-cognitive-architecture.md) · [0006 Storage Abstraction and PostgreSQL](architecture/adrs/0006-storage-abstraction-postgres.md).
 
----
+## Project
 
-*For repository-specific READMEs, see the respective project folders.*
+- **Repository**: [github.com/lpasquali/rune-docs](https://github.com/lpasquali/rune-docs) (and sibling repos `rune`, `rune-operator`, `rune-ui`, `rune-charts`, `rune-audit`, `rune-airgapped`, `rune-ci`).
+- **Security disclosure**: [SECURITY.md](https://github.com/lpasquali/rune-docs/blob/main/SECURITY.md) at the repo root.
+- **Contributing**: [CONTRIBUTING.md](https://github.com/lpasquali/rune-docs/blob/main/CONTRIBUTING.md) — issue and PR process, DoD levels, evidence requirements.
+- **Current state snapshot**: [CURRENT_STATE](context/CURRENT_STATE.md) — the living memory is the authoritative source for what is merged, pending, and known-broken.


### PR DESCRIPTION
## Summary

Phase 0.1 of IA overhaul [epic #273](https://github.com/lpasquali/rune-docs/issues/273) — **keystone** child rewriting `docs/index.md` as a persona-routed landing page. The rewrite delivers the top four of the ten goals listed in #273 at first sight: (1) mission, (2) 90-second pitch, (3) quickstart pointer, and (4–9) routed links to the right next page for every persona.

Closes #274
Epic: #273

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

(Docs-only change: no deps, no agents/drivers, no API/auth/CRD, no workflows, no Dockerfile/Helm.)

## Acceptance Criteria Evidence

- [x] `docs/index.md` has H1 + mission + pitch + 6 persona cards + full-map fallback + footer [evidence: diff shows all six sections in that order, with persona card anchors `#evaluator`, `#operator`, `#developer`, `#agent-author`, `#compliance`, `#adopter`]
- [x] Links validate: `mkdocs build --strict` clean [log: `/tmp/mk-01.log` — exit 0, 0 WARNING, 0 ERROR]
- [x] `pymarkdownlnt scan README.md docs` clean [log: `/tmp/pm-01.log` — exit 0, 0 lines of output]
- [x] A cold reviewer can answer "what is RUNE and where do I start?" from index.md alone in <60 seconds [evidence: mission sentence + 90s pitch appear before the fold; persona cards are the next visible section]

## Test Plan Evidence

### `mkdocs build --strict`

```
$ python -m mkdocs build --strict; echo exit=$?
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/ubuntu/Devel/rune-docs/site
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md
  - architecture/adrs/0007-crossplane-infrastructure-provisioning.md
INFO    -  Documentation built in 0.74 seconds
exit=0
```

(The two orphan-page INFOs predate this PR — pre-existing nav gaps from prior merges. `--strict` treats them as INFO, not WARNING, so exit is 0.)

### `pymarkdown scan README.md docs`

```
$ pymarkdownlnt scan README.md docs; echo exit=$?
exit=0
```

0 issues.

## Breaking Changes

None. Documentation-only. Existing links into `docs/index.md` (from sibling pages or external sources) continue to work — all anchor IDs that previously existed either still exist or are superseded by more descriptive slugs (e.g., the old `🤖 Context (AI Memory)` is now `## Context`; the old `📖 Usage` is now `## Usage`).

## Notes for Reviewer

- **Persona anchor contract**: sibling IA epic children will link to `#evaluator`, `#operator`, `#developer`, `#agent-author`, `#compliance`, `#adopter`. These are simple slugs so no coordination across 10 sibling PRs is needed. If you disagree with the persona names, now is the cheapest time to rename.
- **Placeholders**: the Agent-author and Compliance cards currently point at their tracking issues ([#280](https://github.com/lpasquali/rune-docs/issues/280), [#282](https://github.com/lpasquali/rune-docs/issues/282)) because those sections don't exist yet. Once sibling PRs land, a follow-up commit can replace the issue links with the actual section pages.
- **Old nav preserved**: the existing function-categorized nav (Context / Usage / External projects / Delivery / Operations / Security / Architecture) lives below the persona cards as "Full documentation map" so readers who prefer outlines aren't harmed.
- **Not in scope for this PR**: content for the pages the persona cards link to. That's the other 10 children. QUICKSTART still has stale env-var names; they're fixed in #276. Deployment still has the 6-line Mode 4; expanded in #277.
