### PR TITLE
feat(docker): migrate rune-docs base from nginx to caddy (ADR 0008)

### DIFF
--- a/.vex/permanent.openvex.json
+++ b/.vex/permanent.openvex.json
@@ -4,8 +4,8 @@
   "author": "lpasquali",
   "role": "Project Maintainer",
   "timestamp": "2026-04-05T00:00:00Z",
-  "last_updated": "2026-04-05T00:00:00Z",
-  "version": 2,
+  "last_updated": "2026-04-17T00:00:00Z",
+  "version": 3,
   "statements": [
     {
       "vulnerability": { "name": "CVE-2005-2541" },
@@ -26,28 +26,7 @@
       "products": [{ "@id": "pkg:apk/alpine/openssl" }],
       "status": "not_affected",
       "justification": "component_not_present",
-      "impact_statement": "OpenSSL 3.x vulnerability not applicable to this build configuration."
-    },
-    {
-      "vulnerability": { "name": "CVE-2024-56171" },
-      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2024-56171 affects libxml2 xmlSchemaIDCFillNodeTables (XML Schema validation). libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static HTML/CSS/JS files; no XML parsing or schema validation occurs. The vulnerable code path is unreachable in this deployment."
-    },
-    {
-      "vulnerability": { "name": "CVE-2025-49794" },
-      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2025-49794 is a use-after-free and type confusion vulnerability in libxml2 xmlSchematronGetNode (Schematron validation module). libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static files; no XML or Schematron parsing occurs. The vulnerable code path is unreachable in this deployment."
-    },
-    {
-      "vulnerability": { "name": "CVE-2025-49796" },
-      "products": [{ "@id": "pkg:apk/alpine/libxml2" }],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2025-49796 is a type confusion vulnerability in libxml2 Schematron module. libxml2 2.13.4 is installed in the nginx:1.27.4-alpine base image but nginx does not link to it (verified via ldd /usr/sbin/nginx — no libxml2 reference). The rune-docs container serves only static files; no XML or Schematron parsing occurs. The vulnerable code path is unreachable in this deployment."
+      "impact_statement": "OpenSSL 3.x vulnerability not applicable to this build configuration (Caddy uses Go crypto/tls, not Alpine OpenSSL)."
     }
   ]
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,23 @@
+{
+	admin off
+	auto_https off
+	servers {
+		metrics
+	}
+}
+
+:80 {
+	root * /usr/share/caddy
+	encode gzip zstd
+
+	header {
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		X-Frame-Options "DENY"
+		Permissions-Policy "geolocation=(), microphone=(), camera=()"
+		-Server
+	}
+
+	try_files {path} {path}/ /index.html
+	file_server
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY mkdocs.yml ./
 COPY docs ./docs
 RUN mkdocs build --strict
 
-FROM nginx:1.27.4-alpine
-COPY --from=build /app/site /usr/share/nginx/html
+FROM caddy:2-alpine
+COPY --from=build /app/site /usr/share/caddy
+COPY Caddyfile /etc/caddy/Caddyfile
 EXPOSE 80


### PR DESCRIPTION
## Summary

Replace `FROM nginx:1.27.4-alpine` with `FROM caddy:2-alpine` in `rune-docs/Dockerfile`, add a minimal hardened `Caddyfile`, and delete the three libxml2 VEX entries that no longer apply. First implementation child of epic #295 after ADR 0008 (#296) was accepted.

Closes #297
Epic: #295

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

- [x] Tested in **docker-compose mode** — plain `docker build` + `docker run -p 18081:80` is equivalent for this image (single static-serving container with no compose topology).
- [x] Tested in **kind (Kubernetes) mode** — not applicable; rune-docs is a documentation site served directly from the container and does not ship a kind E2E harness. CI container build is the relevant gate.
- [x] Tested in **standalone CLI mode** — n/a; there is no CLI path for rune-docs.
- [x] **Breaking change audit** — no API, no persistent data, no cross-component contract changes. The container still listens on :80, same URL paths, same MkDocs output. Downstream consumers (rune-airgapped bundle, `ghcr.io/lpasquali/rune-docs` image) consume by tag; the only downstream that pins the base image (rune-airgapped `INFRA_IMAGES`) is handled in #86.
- [x] **Dependency CVE audit** (deps changed: base image) — `apk list --installed` on the new image shows no `libxml2`, `libxslt`, `pcre`, or `openssl` packages. Alpine package count dropped from the nginx-based image's (~60+) to 33. CI `RuneGate/Security/SBOM-and-CVE-Policy` will run `grype`/SBOM on the built image.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:dep caddy` | PASS | Caddy is Apache-2.0, Go (memory-safe), actively maintained (ADR 0008 §Alternatives). `caddy:2-alpine` is an official upstream image. |
| `cyber check:supply-chain` | PASS | Base image pulled from Docker Hub official library; no new third-party dep. VEX register updated (3 entries removed; version bumped). |
| `legal check:dep caddy` | PASS | Apache-2.0; same license family as the rest of RUNE; no new SPDX concerns. |

## Acceptance Criteria Evidence

- [x] `docker build` produces a working image; `curl -I http://localhost:18081/ -f` returns 200 OK.
  - `HTTP/1.1 200 OK`, `Content-Type: text/html; charset=utf-8`, Content-Length 43 571 on the landing page.
- [x] Security headers present.
  - `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `X-Frame-Options: DENY`, `Permissions-Policy: geolocation=(), microphone=(), camera=()`; `Server:` header suppressed.
- [x] Image size within ±10% of the previous nginx-based image.
  - `rune-docs:nginx-old` (previous Dockerfile from `main`): **86 MB**.
  - `rune-docs:caddy-297` (this branch): **94.6 MB**.
  - Delta: **+10.0%** — at the acceptance boundary. The Caddy image brings ACME, a larger Go binary, and zstd support; the libxml2 / libxslt / pcre / openssl footprint is gone. The security win justifies the size parity.
- [x] `docker run` works; container binds to :80; listener confirmed via `curl`.
- [x] Zero libxml2 findings in new image.
  - `apk list --installed | grep -i libxml2` → empty.
  - `apk list --installed | awk -F'-' '{print $1}' | grep -E '^(libxml|libxslt|pcre|openssl)' | sort -u` → empty.
- [x] VEX file valid OpenVEX; three libxml2 entries removed; `version: 2 → 3`; `last_updated` refreshed; CVE-2024-2511 impact note updated to reference Caddy Go crypto/tls.
- [x] ADR 0008 (#296) merged before this PR opened.

## Test Plan Evidence

```
$ docker build -t rune-docs:caddy-297 .                             # OK
$ docker run -d --name t -p 18081:80 rune-docs:caddy-297            # OK
$ curl -sI http://127.0.0.1:18081/ | head
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 43571
Content-Type: text/html; charset=utf-8
Permissions-Policy: geolocation=(), microphone=(), camera=()
Referrer-Policy: strict-origin-when-cross-origin
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
$ docker exec t apk list --installed | grep -i libxml2              # (empty)
$ docker exec t du -sh /usr/share/caddy                             # 7.7M
```

## Breaking Changes

None for consumers. The image listens on the same port, serves the same URLs, and its upstream name (`ghcr.io/lpasquali/rune-docs`) is unchanged. The only downstream that pins the **base** image tag is rune-airgapped `INFRA_IMAGES`, handled in #86.

## Notes for Reviewer

- `Caddyfile` disables the admin API (`admin off`) and auto-HTTPS (`auto_https off`) because TLS is terminated at the cluster Service / Ingress, not in the container. `servers { metrics }` leaves room for the Prometheus metrics endpoint to be wired later without another config change.
- Content-Security-Policy intentionally **not** set in this PR — MkDocs Material's inline scripts/assets make a correct CSP non-trivial, and a wrong CSP breaks the site. Follow-up issue can add one after a proper test pass.
- VEX `version: 3` (was 2); `last_updated: 2026-04-17T00:00:00Z`.

Made with [Cursor](https://cursor.com)