### PR TITLE
docs(reference): centralized external links & spec catalog

### DIFF
--- a/docs/context/SYSTEM_PROMPT.md
+++ b/docs/context/SYSTEM_PROMPT.md
@@ -13,6 +13,7 @@ RUNE (Reliability Use-case Numeric Evaluator) is an AI agent benchmarking and co
 4. **[Developer Guide](../usage/DEVELOPER_GUIDE.md)** — repos, env, build/test/lint, deployment DoD steps.
 5. **[Coding Standards](CODING_STANDARDS.md)** — style, coverage floors, tier layout.
 6. **[Audit Agents](../delivery/AUDIT_AGENTS.md)** — legal/cyber checks (when and how).
+7. **[External Links](../reference/EXTERNAL_LINKS.md)** — official docs and spec URLs for every standard RUNE complies with and every tool RUNE uses; canonical source for citation URLs.
 
 Repos under `~/Devel/`: `rune/`, `rune-operator/`, `rune-ui/`, `rune-charts/`, `rune-docs/`, `rune-audit/`, `rune-airgapped/`, `rune-ci/`.
 

--- a/docs/delivery/AUDIT_AGENTS.md
+++ b/docs/delivery/AUDIT_AGENTS.md
@@ -17,7 +17,7 @@ Runs a comprehensive OSS licensing and legal compliance audit across all 7 repos
 - No-bundling policy enforcement across all docs and Dockerfiles
 - Patent clause implications (Apache-2.0 Section 3)
 - Helm Chart.yaml and pyproject.toml license metadata
-- SPDX identifier compliance
+- [SPDX](https://spdx.dev/) identifier compliance (see [SPDX License List](https://spdx.org/licenses/))
 - Export control considerations for cryptographic components
 
 **What to read:** All LICENSE and NOTICE files, dependency manifests (pyproject.toml, go.mod, requirements.txt), chains.csv Ecosystem column, CI workflows (license gates), VEX files, GOLDEN_IMAGE.md, all Dockerfiles, SECURITY.md, CODING_STANDARDS.md (no-bundling policy).
@@ -42,7 +42,7 @@ Runs a comprehensive OSS licensing and legal compliance audit across all 7 repos
 Triggered when a dependency is added or bumped. Focused on a single package and its transitive tree.
 
 **Scope:**
-- Run `pip-licenses` or `go-licenses` for the specific package and its transitive dependencies
+- Run [`pip-licenses`](https://pypi.org/project/pip-licenses/) or [`go-licenses`](https://github.com/google/go-licenses) for the specific package and its transitive dependencies
 - Check each transitive dep against the blocked license list (GPL-2.0, GPL-3.0, AGPL-3.0 and their -or-later variants)
 - Check for LGPL (warning tier — requires careful handling in Python packaging)
 - Verify the package is declared in the appropriate manifest (not just installed in Dockerfile)
@@ -110,7 +110,7 @@ Runs a comprehensive cybersecurity compliance audit against IEC 62443-4-1 ML4 an
 Triggered alongside `legal check:dep` when a dependency changes.
 
 **Scope:**
-- Run `pip-audit` or `govulncheck` against the updated dependency set
+- Run [`pip-audit`](https://pypi.org/project/pip-audit/) or [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against the updated dependency set
 - Check if the new/bumped package introduces any known CVE
 - Check if the new version drops support for any security fix present in the old version
 - Verify the dependency is pinned appropriately (not floating on `>=` for security-critical packages)
@@ -125,7 +125,7 @@ Triggered when API endpoints, auth mechanisms, Helm values, or CRD schemas chang
 - Review authentication changes: are tokens still hashed? Is auth bypass (`RUNE_API_AUTH_DISABLED`) confined to dev mode?
 - Review authorization changes: is tenant scoping preserved? Is RBAC for HolmesGPT still read-only?
 - Review schema changes: are new fields additive (backward compatible) or breaking?
-- Check for OWASP API Top 10 risks in the change (injection, broken auth, excessive data exposure)
+- Check for [OWASP API Security Top 10](https://owasp.org/www-project-api-security/) risks in the change (injection, broken auth, excessive data exposure)
 
 **Report:** Findings per OWASP/IEC reference with severity.
 
@@ -154,3 +154,8 @@ Triggered when VEX statements are added or modified.
 - Cross-reference CVSS scores against the project's threshold policy
 
 **Report:** Per-statement assessment — DEFENSIBLE or NEEDS REVISION with specific technical gap.
+
+ 
+## References
+
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) — full list of tools ([Trivy](https://trivy.dev/), [Grype](https://github.com/anchore/grype), [Syft](https://github.com/anchore/syft), [Bandit](https://bandit.readthedocs.io/), [gosec](https://github.com/securego/gosec), [gitleaks](https://github.com/gitleaks/gitleaks)) and standards ([OWASP Top 10](https://owasp.org/www-project-top-ten/), [SPDX](https://spdx.dev/), [SLSA](https://slsa.dev/spec/v1.0/), [IEC 62443-4-1](https://webstore.iec.ch/publication/33615)) referenced in the checks above.

--- a/docs/reference/EXTERNAL_LINKS.md
+++ b/docs/reference/EXTERNAL_LINKS.md
@@ -1,0 +1,204 @@
+# External Links & Official Documentation
+
+Canonical catalog of official documentation and specification URLs for every standard RUNE complies with and every third-party tool or platform component RUNE uses. Both humans reading the docs and agents consulting them should start here when they need an authoritative upstream URL.
+
+Each row contains the full URL as bare text so that automated tooling (grep, `awk`, LLM extraction) can lift URLs without parsing markdown link syntax. The same URLs appear as hyperlinks for one-click navigation.
+
+Contents:
+
+- [1. Compliance Standards & Specifications](#1-compliance-standards-specifications)
+- [2. Security & Compliance Tools](#2-security-compliance-tools)
+- [3. Development Tools](#3-development-tools)
+- [4. Platform & Infrastructure](#4-platform-infrastructure)
+- [5. RUNE Repositories](#5-rune-repositories)
+- [Freshness & updates](#freshness-updates)
+
+---
+
+## 1. Compliance Standards & Specifications
+
+RUNE claims alignment with — or targets compliance against — the following standards. Links point to the official source of each spec; paywalled standards also include a free overview URL.
+
+| Name | Version | Official URL | Notes |
+|---|---|---|---|
+| IEC 62443-4-1 (Secure product development lifecycle) | 2018 | <https://webstore.iec.ch/publication/33615> | Paywalled (IEC Webstore) |
+| IEC 62443 series — ISA overview | — | <https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards> | Free overview of the full series |
+| SLSA — Supply-chain Levels for Software Artifacts | v1.0 | <https://slsa.dev/spec/v1.0/> | RUNE targets Level 3 |
+| SLSA — project site | — | <https://slsa.dev/> | Landing + tooling |
+| SLSA Provenance predicate | v1 | <https://slsa.dev/spec/v1.0/provenance> | Build attestation format |
+| OWASP Top 10 | 2021 | <https://owasp.org/www-project-top-ten/> | Web application risks |
+| OWASP Web Security Testing Guide | v4.2 | <https://owasp.org/www-project-web-security-testing-guide/> | Pentest methodology |
+| OWASP API Security Top 10 | 2023 | <https://owasp.org/www-project-api-security/> | API risk categories |
+| NIST SP 800-61r2 — Computer Security Incident Handling Guide | rev 2 | <https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final> | Incident response baseline |
+| NIST SP 800-30r1 — Guide for Conducting Risk Assessments | rev 1 | <https://csrc.nist.gov/publications/detail/sp/800-30/rev-1/final> | Risk assessment methodology |
+| NIST Cybersecurity Framework | 2.0 | <https://www.nist.gov/cyberframework> | Core governance reference |
+| Microsoft STRIDE threat-modelling taxonomy | — | <https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats> | Threat categories |
+| PTES — Penetration Testing Execution Standard | — | <http://www.pentest-standard.org/> | Pentest execution stages |
+| SPDX — Software Package Data Exchange | 2.3 | <https://spdx.dev/> | SBOM format |
+| SPDX License List | — | <https://spdx.org/licenses/> | License identifiers used in SPDX headers |
+| Semantic Versioning | 2.0.0 | <https://semver.org/> | Release versioning rules |
+| in-toto attestation framework | v1 | <https://in-toto.io/> | Provenance foundation |
+| CVSS — Common Vulnerability Scoring System | 3.1 | <https://www.first.org/cvss/v3-1/specification-document> | CVE severity scoring |
+| CycloneDX SBOM | 1.5 | <https://cyclonedx.org/specification/overview/> | Alternative SBOM format |
+| Conventional Commits | 1.0.0 | <https://www.conventionalcommits.org/en/v1.0.0/> | Commit message format |
+| Keep a Changelog | 1.1.0 | <https://keepachangelog.com/en/1.1.0/> | Changelog format |
+
+## 2. Security & Compliance Tools
+
+Tools invoked by RUNE CI, security workflows, or compliance evidence collection.
+
+| Tool | Docs URL | Use in RUNE |
+|---|---|---|
+| Sigstore | <https://docs.sigstore.dev/> | Signing infrastructure |
+| cosign | <https://docs.sigstore.dev/cosign/overview/> | Container image signing |
+| Rekor | <https://docs.sigstore.dev/logging/overview/> | Transparency log |
+| Fulcio | <https://docs.sigstore.dev/certificate_authority/overview/> | Keyless signing CA |
+| gitleaks | <https://github.com/gitleaks/gitleaks> | Secret scanning (CI) |
+| Trivy | <https://trivy.dev/> | Container CVE + config scan |
+| Grype | <https://github.com/anchore/grype> | Container CVE scan |
+| Syft | <https://github.com/anchore/syft> | SBOM generation |
+| pip-audit | <https://pypi.org/project/pip-audit/> | Python CVE audit |
+| pip-licenses | <https://pypi.org/project/pip-licenses/> | Python license check |
+| govulncheck | <https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck> | Go CVE audit |
+| go-licenses | <https://github.com/google/go-licenses> | Go license check |
+| Bandit | <https://bandit.readthedocs.io/> | Python SAST |
+| gosec | <https://github.com/securego/gosec> | Go SAST |
+| CodeQL | <https://codeql.github.com/docs/> | Static analysis (CI) |
+| Dependabot | <https://docs.github.com/en/code-security/dependabot> | Dependency updates |
+| TLA+ Tools | <https://lamport.azurewebsites.net/tla/tools.html> | Formal specs |
+| TLA+ Toolbox | <https://lamport.azurewebsites.net/tla/toolbox.html> | Model checker UI |
+| VS Code TLA+ extension | <https://marketplace.visualstudio.com/items?itemName=alygin.vscode-tlaplus> | Editor support |
+| tpm2-tools | <https://tpm2-tools.readthedocs.io/> | TPM attestation |
+| OpenSSF Scorecard | <https://scorecard.dev/> | Supply-chain security grading |
+
+## 3. Development Tools
+
+Per-language and per-format tooling used across RUNE repositories.
+
+### Python
+
+| Tool | Docs URL | Use in RUNE |
+|---|---|---|
+| Python Language Reference | <https://docs.python.org/3/> | Language reference (3.14) |
+| black | <https://black.readthedocs.io/> | Formatter |
+| ruff | <https://docs.astral.sh/ruff/> | Linter |
+| mypy | <https://mypy.readthedocs.io/> | Type checker |
+| pytest | <https://docs.pytest.org/> | Test runner |
+| pytest-cov | <https://pytest-cov.readthedocs.io/> | Coverage plugin |
+| coverage.py | <https://coverage.readthedocs.io/> | Coverage engine |
+| respx | <https://lundberg.github.io/respx/> | httpx mocking |
+| Hypothesis | <https://hypothesis.readthedocs.io/> | Property-based / fuzz testing |
+| httpx | <https://www.python-httpx.org/> | HTTP client |
+| Typer | <https://typer.tiangolo.com/> | CLI framework |
+| Pydantic | <https://docs.pydantic.dev/> | Data validation |
+| FastAPI | <https://fastapi.tiangolo.com/> | API framework (rune-ui) |
+| Jinja2 | <https://jinja.palletsprojects.com/> | Templating (rune-ui) |
+
+### Go
+
+| Tool | Docs URL | Use in RUNE |
+|---|---|---|
+| Go Language | <https://go.dev/doc/> | Language reference (1.25) |
+| gofmt | <https://pkg.go.dev/cmd/gofmt> | Formatter |
+| go vet | <https://pkg.go.dev/cmd/vet> | Correctness checks |
+| staticcheck | <https://staticcheck.dev/> | Static analysis |
+| Go native fuzzing | <https://go.dev/doc/security/fuzz/> | Fuzz testing |
+| Kubebuilder | <https://book.kubebuilder.io/> | Operator scaffolding |
+| controller-runtime | <https://pkg.go.dev/sigs.k8s.io/controller-runtime> | Operator framework |
+
+### Docs / Markdown / Shell / YAML
+
+| Tool | Docs URL | Use in RUNE |
+|---|---|---|
+| MkDocs | <https://www.mkdocs.org/> | Docs site builder |
+| MkDocs Material | <https://squidfunk.github.io/mkdocs-material/> | Docs theme |
+| mike | <https://github.com/jimporter/mike> | MkDocs version manager |
+| PyMarkdown | <https://github.com/jackdewinter/pymarkdown> | Markdown linter |
+| Mermaid.js | <https://mermaid.js.org/> | Diagrams (only diagram format allowed) |
+| shellcheck | <https://www.shellcheck.net/> | Shell linter |
+| yamllint | <https://yamllint.readthedocs.io/> | YAML linter |
+
+## 4. Platform & Infrastructure
+
+Runtime components, LLM backends, agents, and infrastructure that RUNE integrates with.
+
+### LLM backends and agents
+
+| Component | Docs URL | Use in RUNE |
+|---|---|---|
+| Ollama | <https://ollama.com/> | Default local LLM backend |
+| Ollama API reference | <https://github.com/ollama/ollama/blob/main/docs/api.md> | HTTP API |
+| LiteLLM | <https://docs.litellm.ai/> | Multi-provider router |
+| HolmesGPT | <https://github.com/robusta-dev/holmesgpt> | SRE diagnostics agent |
+| LangGraph | <https://langchain-ai.github.io/langgraph/> | Multi-agent orchestration |
+| CrewAI | <https://docs.crewai.com/> | Agent framework |
+| Model Context Protocol (MCP) | <https://modelcontextprotocol.io/> | Agent context protocol |
+| A2A Protocol | <https://a2aproject.github.io/A2A/> | Agent-to-agent interop |
+| InvokeAI | <https://invoke-ai.github.io/InvokeAI/> | Art/creative agent |
+| ComfyUI | <https://docs.comfy.org/> | Art/creative agent |
+
+### Compute & provisioning
+
+| Component | Docs URL | Use in RUNE |
+|---|---|---|
+| Vast.ai | <https://vast.ai/docs/> | GPU provisioning resource |
+| Crossplane | <https://docs.crossplane.io/latest/> | Infrastructure provisioning (ADR 0007) |
+
+### Kubernetes & deployment
+
+| Component | Docs URL | Use in RUNE |
+|---|---|---|
+| Kubernetes | <https://kubernetes.io/docs/> | Orchestration platform |
+| kubectl | <https://kubernetes.io/docs/reference/kubectl/> | K8s CLI |
+| Helm | <https://helm.sh/docs/> | Package manager |
+| kind | <https://kind.sigs.k8s.io/> | Local K8s (CI + dev) |
+| Pod Security Admission | <https://kubernetes.io/docs/concepts/security/pod-security-admission/> | PSA restricted baseline |
+| Gateway API Inference Extension | <https://gateway-api-inference-extension.sigs.k8s.io/> | Planned `k8s-inference` backend |
+| CloudNativePG | <https://cloudnative-pg.io/> | PostgreSQL operator (ADR 0006) |
+| CloudNativePG Helm charts | <https://cloudnative-pg.github.io/charts> | CNPG distribution |
+
+### Secrets & storage
+
+| Component | Docs URL | Use in RUNE |
+|---|---|---|
+| HashiCorp Vault | <https://developer.hashicorp.com/vault/docs> | Secrets management |
+| Vault Agent Injector | <https://developer.hashicorp.com/vault/docs/platform/k8s/injector> | K8s secret injection |
+| SeaweedFS | <https://github.com/seaweedfs/seaweedfs> | S3-compatible object store (local dev) |
+| SQLite | <https://www.sqlite.org/docs.html> | Default embedded store |
+| PostgreSQL | <https://www.postgresql.org/docs/> | Scale-out store target (ADR 0006) |
+
+### Container & CI/CD
+
+| Component | Docs URL | Use in RUNE |
+|---|---|---|
+| Docker | <https://docs.docker.com/> | Container runtime |
+| Docker Compose | <https://docs.docker.com/compose/> | Local stack |
+| OCI Image Spec | <https://github.com/opencontainers/image-spec> | Image format |
+| GitHub Actions | <https://docs.github.com/en/actions> | CI/CD platform |
+| GitHub Actions build-type attestation | <https://actions.github.io/buildtypes/workflow/v1> | SLSA builder reference |
+| crane | <https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md> | Registry CLI (airgapped) |
+| zot registry | <https://zotregistry.dev/> | Airgapped OCI registry |
+| Helmfile | <https://helmfile.readthedocs.io/> | Multi-chart orchestration |
+| Cilium | <https://docs.cilium.io/> | CNI (airgapped) |
+
+## 5. RUNE Repositories
+
+GitHub repositories that make up the RUNE platform. All under the [`lpasquali`](https://github.com/lpasquali) user.
+
+| Repo | URL | Purpose |
+|---|---|---|
+| rune | <https://github.com/lpasquali/rune> | Core Python platform (CLI, API, drivers, backends) |
+| rune-operator | <https://github.com/lpasquali/rune-operator> | Kubernetes operator (Go) |
+| rune-ui | <https://github.com/lpasquali/rune-ui> | HTMX frontend |
+| rune-charts | <https://github.com/lpasquali/rune-charts> | Helm charts |
+| rune-docs | <https://github.com/lpasquali/rune-docs> | This documentation hub |
+| rune-audit | <https://github.com/lpasquali/rune-audit> | Compliance & audit evidence service |
+| rune-airgapped | <https://github.com/lpasquali/rune-airgapped> | Air-gapped OCI bundle tooling |
+| rune-ci | <https://github.com/lpasquali/rune-ci> | Shared GitHub Actions workflows |
+
+## Freshness & updates
+
+- Add a row here whenever rune-docs introduces a new external dependency, tool, or compliance claim.
+- If an upstream URL moves, update it here first and then grep the docs for any stale inline references to fix.
+- For paywalled standards (IEC), link to the official webstore entry and, when available, a free overview page.
+- Version columns should reflect the version RUNE currently targets or cites, not simply the latest upstream release.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,7 @@
+# Reference
+
+Authoritative pointers to external resources used by RUNE.
+
+- **[External Links & Official Docs](EXTERNAL_LINKS.md)** — every standard RUNE complies with and every tool RUNE uses, each with an official documentation or specification URL.
+
+This section is the first place to look when you need a canonical upstream URL for a standard, tool, or platform component cited elsewhere in rune-docs.

--- a/docs/security/FUZZ_TESTING.md
+++ b/docs/security/FUZZ_TESTING.md
@@ -149,9 +149,10 @@ Remediation SLAs follow the penetration testing program
 
 ## 8. References
 
-- IEC 62443-4-1:2018 SVV-5 -- Fuzz testing
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) SVV-5 -- Fuzz testing
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [PENTEST.md](PENTEST.md) -- Penetration testing program
 - [RISK_ASSESSMENT.md](RISK_ASSESSMENT.md) -- Threat model informing fuzz targets
-- Hypothesis documentation: <https://hypothesis.readthedocs.io/>
-- Go fuzzing: <https://go.dev/doc/security/fuzz/>
+- [Hypothesis](https://hypothesis.readthedocs.io/) -- Python property-based testing
+- [Go native fuzzing](https://go.dev/doc/security/fuzz/)
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools

--- a/docs/security/IMAGE_SIGNING.md
+++ b/docs/security/IMAGE_SIGNING.md
@@ -194,9 +194,13 @@ will be reassessed from 15 (High) to an expected 4 (Low).
 
 ## 9. References
 
-- SLSA v1.0 -- Supply-chain Levels for Software Artifacts
-- Sigstore documentation: <https://docs.sigstore.dev/>
-- cosign documentation: <https://docs.sigstore.dev/cosign/overview/>
+- [SLSA v1.0](https://slsa.dev/spec/v1.0/) -- Supply-chain Levels for Software Artifacts
+- [SLSA Provenance v1](https://slsa.dev/spec/v1.0/provenance) -- Attestation format
+- [Sigstore documentation](https://docs.sigstore.dev/)
+- [cosign](https://docs.sigstore.dev/cosign/overview/)
+- [Rekor](https://docs.sigstore.dev/logging/overview/) -- Transparency log
+- [SPDX](https://spdx.dev/) -- SBOM format
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [RISK_REGISTER.md](RISK_REGISTER.md) -- Risk R-005
 - [RISK_ASSESSMENT.md](RISK_ASSESSMENT.md) -- Threat modeling methodology

--- a/docs/security/INCIDENT_RESPONSE.md
+++ b/docs/security/INCIDENT_RESPONSE.md
@@ -183,9 +183,10 @@ During any P0 or P1 incident:
 
 ## 10. References
 
-- IEC 62443-4-1:2018 DM-2 -- Defect management
-- NIST Cybersecurity Framework -- Respond (RS)
-- NIST SP 800-61r2 -- Computer Security Incident Handling Guide
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) DM-2 -- Defect management
+- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework) -- Respond (RS)
+- [NIST SP 800-61r2](https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final) -- Computer Security Incident Handling Guide
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [RISK_REGISTER.md](RISK_REGISTER.md) -- Risk register
 - [IMAGE_SIGNING.md](IMAGE_SIGNING.md) -- Container image verification

--- a/docs/security/PENTEST.md
+++ b/docs/security/PENTEST.md
@@ -134,9 +134,11 @@ vulnerability closure policy in [SYSTEM_PROMPT.md](../context/SYSTEM_PROMPT.md).
 
 ## 9. References
 
-- IEC 62443-4-1:2018 SVV-4 -- Penetration testing
-- OWASP Testing Guide v4
-- PTES (Penetration Testing Execution Standard)
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) SVV-4 -- Penetration testing
+- [OWASP Web Security Testing Guide v4.2](https://owasp.org/www-project-web-security-testing-guide/)
+- [PTES](http://www.pentest-standard.org/) -- Penetration Testing Execution Standard
+- [OWASP API Security Top 10 (2023)](https://owasp.org/www-project-api-security/)
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [RISK_ASSESSMENT.md](RISK_ASSESSMENT.md) -- Threat model informing test scope
 - [FUZZ_TESTING.md](FUZZ_TESTING.md) -- Complementary fuzz testing program

--- a/docs/security/RISK_ASSESSMENT.md
+++ b/docs/security/RISK_ASSESSMENT.md
@@ -139,9 +139,10 @@ their scores, treatment decisions, and review status.
 
 ## 7. References
 
-- IEC 62443-4-1:2018 SM-5 -- Security risk assessment
-- Microsoft STRIDE threat model
-- NIST SP 800-30 -- Guide for Conducting Risk Assessments
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) SM-5 -- Security risk assessment
+- [Microsoft STRIDE](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats) threat model
+- [NIST SP 800-30r1](https://csrc.nist.gov/publications/detail/sp/800-30/rev-1/final) -- Guide for Conducting Risk Assessments
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [RISK_REGISTER.md](RISK_REGISTER.md) -- Active risk register
 - [PENTEST.md](PENTEST.md) -- Penetration testing (validates risk assessments)

--- a/docs/security/RISK_REGISTER.md
+++ b/docs/security/RISK_REGISTER.md
@@ -71,7 +71,8 @@ quadrantChart
 
 ## 6. References
 
-- IEC 62443-4-1:2018 SM-5 -- Security risk assessment
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) SM-5 -- Security risk assessment
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools
 - [RISK_ASSESSMENT.md](RISK_ASSESSMENT.md) -- Methodology
 - [SDL.md](SDL.md) -- Security Development Lifecycle
 - [INCIDENT_RESPONSE.md](INCIDENT_RESPONSE.md) -- Response procedures for realized risks

--- a/docs/security/SDL.md
+++ b/docs/security/SDL.md
@@ -124,8 +124,11 @@ flowchart LR
 
 ## 9. References
 
-- IEC 62443-4-1:2018 -- Product security development lifecycle requirements
-- SLSA v1.0 -- Supply-chain Levels for Software Artifacts
+- [IEC 62443-4-1:2018](https://webstore.iec.ch/publication/33615) -- Product security development lifecycle requirements ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- [SLSA v1.0](https://slsa.dev/spec/v1.0/) -- Supply-chain Levels for Software Artifacts
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/) -- Web application security risks
+- [Semantic Versioning 2.0.0](https://semver.org/) -- Release versioning
+- [External Links Catalog](../reference/EXTERNAL_LINKS.md) -- Complete list of standards and tools cited across rune-docs
 - [SYSTEM_PROMPT.md](../context/SYSTEM_PROMPT.md) -- Core constraints and SOP
 - [RISK_ASSESSMENT.md](RISK_ASSESSMENT.md) -- Threat modeling methodology
 - [RISK_REGISTER.md](RISK_REGISTER.md) -- Active risk register

--- a/docs/security/SECURITY_TRAINING.md
+++ b/docs/security/SECURITY_TRAINING.md
@@ -1,6 +1,6 @@
 # Security Training and Competency Records
 
-IEC 62443-4-1 SM-3 requires that all personnel involved in the secure development lifecycle have documented security training and competency verification.
+[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) SM-3 requires that all personnel involved in the secure development lifecycle have documented security training and competency verification. For the full list of standards cited in this document see the [External Links Catalog](../reference/EXTERNAL_LINKS.md).
 
 ## Training Requirements
 
@@ -8,10 +8,10 @@ IEC 62443-4-1 SM-3 requires that all personnel involved in the secure developmen
 
 | Topic | Frequency | Verification |
 |---|---|---|
-| OWASP Top 10 (Web) | Annual | Quiz or certification |
+| [OWASP Top 10](https://owasp.org/www-project-top-ten/) (Web) | Annual | Quiz or certification |
 | Secure coding practices (Python, Go) | Annual | Code review participation |
-| Supply chain security (SLSA, SBOM, VEX) | Annual | Tooling proficiency demo |
-| IEC 62443 awareness | At onboarding + annual | Self-assessment |
+| Supply chain security ([SLSA](https://slsa.dev/spec/v1.0/), [SPDX](https://spdx.dev/) SBOM, VEX) | Annual | Tooling proficiency demo |
+| [IEC 62443](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards) awareness | At onboarding + annual | Self-assessment |
 | Incident response procedures | Annual | Tabletop exercise participation |
 
 ### Role-Specific Training

--- a/docs/usage/OLLAMA_REFERENCE.md
+++ b/docs/usage/OLLAMA_REFERENCE.md
@@ -1,7 +1,7 @@
  
 # LLM Backend Reference
 
-Quick reference for the LLM backend integration layer. RUNE supports pluggable backends via the `LLMBackend` protocol. The default backend is Ollama.
+Quick reference for the LLM backend integration layer. RUNE supports pluggable backends via the `LLMBackend` protocol. The default backend is [Ollama](https://ollama.com/) ([API reference](https://github.com/ollama/ollama/blob/main/docs/api.md)). See the [External Links Catalog](../reference/EXTERNAL_LINKS.md) for all backend, agent, and provider docs.
 
  
 ## Quick Start (Generic API)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
       - System Prompt: context/SYSTEM_PROMPT.md
       - Current State: context/CURRENT_STATE.md
       - Coding Standards: context/CODING_STANDARDS.md
+  - Reference:
+      - Overview: reference/index.md
+      - External Links & Official Docs: reference/EXTERNAL_LINKS.md
   - Usage:
       - Quickstart: usage/QUICKSTART.md
       - Developer Guide: usage/DEVELOPER_GUIDE.md
@@ -98,6 +101,7 @@ nav:
   - Architecture:
       - Threat Model: architecture/THREAT_MODEL.md
       - Security Requirements: architecture/SECURITY_REQUIREMENTS.md
+      - Quantitative Security Requirements: architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md
       - System Design: architecture/SYSTEM_DESIGN.md
       - Infrastructure: architecture/INFRASTRUCTURE.md
       - Formal Specs: architecture/FORMAL_SPECS.md
@@ -108,4 +112,5 @@ nav:
           - "0004: Operator Parity": architecture/adrs/0004-operator-feature-parity.md
           - "0005: Advanced Cognitive Architecture": architecture/adrs/0005-advanced-cognitive-architecture.md
           - "0006: Storage Abstraction and PostgreSQL": architecture/adrs/0006-storage-abstraction-postgres.md
+          - "0007: Crossplane Infrastructure Provisioning": architecture/adrs/0007-crossplane-infrastructure-provisioning.md
           - "0008: Single container-level HTTP tool and ingress-agnostic charts": architecture/adrs/0008-single-container-http-tool-and-ingress-agnosticism.md


### PR DESCRIPTION
## Summary

Adds a canonical catalog page `docs/reference/EXTERNAL_LINKS.md` with official documentation and specification URLs for every standard RUNE complies with and every third-party tool RUNE uses. Inline-links the References sections of existing security and delivery docs to the authoritative URLs. Fixes two orphan nav entries discovered during the pass (ADR 0007, QUANTITATIVE_SECURITY_REQUIREMENTS).

Closes #306
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

<!-- N/A — Level 3 -->

## Level 2 Checklist

<!-- N/A — Level 3 -->

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] New canonical catalog page `docs/reference/EXTERNAL_LINKS.md` — evidence: file added, 5 sections (Compliance Standards, Security tools, Dev tools, Platform & Infra, RUNE Repositories)
- [x] New `docs/reference/index.md` landing page — evidence: file added
- [x] Wired into `mkdocs.yml` nav under Reference — evidence: `mkdocs build --strict` exits 0 and renders `/reference/` section
- [x] `SYSTEM_PROMPT.md` "Read first" item 7 — evidence: diff in `docs/context/SYSTEM_PROMPT.md`
- [x] Inline hyperlinks in 9 docs' References sections — evidence: diffs in `docs/security/*`, `docs/delivery/AUDIT_AGENTS.md`, `docs/usage/OLLAMA_REFERENCE.md`
- [x] Nav entry for orphan `architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md` — evidence: `mkdocs.yml` diff
- [x] `mkdocs build --strict` zero-warning — evidence: local build log (exit 0, no warnings)
- [x] `pymarkdown scan` clean — evidence: local scan (exit 0)
- [x] Every standard and tool cited in rune-docs resolves to its official URL from the catalog — evidence: catalog rows include URLs for IEC 62443-4-1, SLSA v1.0 / Provenance, OWASP Top 10 / Testing Guide / API Top 10, NIST 800-30 / 800-61r2 / CSF, STRIDE, PTES, SPDX, semver, pip-audit, pip-licenses, govulncheck, go-licenses, bandit, gosec, gitleaks, trivy, grype, syft, cosign, Rekor, Sigstore, Ollama, HolmesGPT, LangGraph, LiteLLM, Vast.ai, CloudNativePG, Crossplane, Vault, Helm, kind, kubectl, MkDocs, PyMarkdown, GitHub Actions, Hypothesis, Go fuzz, TLA+, and others.
- [x] SYSTEM_PROMPT references EXTERNAL_LINKS.md — evidence: diff

## Test Plan Evidence

- [x] `python -m mkdocs build --strict` → exit 0, no warnings (verified locally on branch tip)
- [x] `pymarkdown scan README.md docs` → exit 0 (verified locally on branch tip)

## Breaking Changes

None. Pure additive docs change.

## Notes for Reviewer

- The `.vscode/launch.json` developer convenience file created earlier in-session is deliberately **not** included in this PR (it is developer-machine-specific with a hardcoded venv path). Happy to open a separate PR to gitignore `.vscode/` if desired.
- ADR 0007 (Crossplane Infrastructure Provisioning) was on disk on `main` but missing from the nav — added.
- `architecture/QUANTITATIVE_SECURITY_REQUIREMENTS.md` was also orphan — added to nav under Architecture.
- Paywalled IEC 62443 links point to the official IEC Webstore publication page (free abstract); the free ISA overview URL is also linked as a companion reference where appropriate.