### PR TITLE
chore(gitignore): ignore .vscode/ developer workspace state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ sbom/
 
 # Claude Code per-project agent state
 .claude/
+
+# VS Code per-developer workspace state (launch configs, tasks, settings)
+.vscode/


### PR DESCRIPTION
## Summary

Add `.vscode/` to `.gitignore` so per-developer VS Code workspace state (launch configs, tasks, settings) cannot enter the repo. Matches the existing `.claude/` pattern.

Closes #310
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

<!-- N/A — Level 3 -->

## Level 2 Checklist

<!-- N/A — Level 3 -->

## Level 3 Checklist

- [x] `mkdocs build --strict` passes
- [x] `pymarkdown scan README.md docs` passes (no markdown changes)

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] `.vscode/` listed in `.gitignore` with explanatory comment — evidence: diff
- [x] `git check-ignore -v .vscode/` succeeds — evidence: `.gitignore:15:.vscode/	.vscode/`
- [x] `mkdocs build --strict` still passes — evidence: exit 0 locally

## Test Plan Evidence

- [x] `git check-ignore -v .vscode/` confirms `.gitignore` line 15 matches
- [x] `mkdocs build --strict` → exit 0
- [x] `git status` on a fresh `.vscode/launch.json` shows it untracked and ignored

## Breaking Changes

None. Config-only addition; no effect on runtime, builds, or CI.

## Notes for Reviewer

One-line gitignore addition; companion to #307 (external links catalog PR). The `.vscode/launch.json` developer convenience file created earlier in the session motivated this rule, but no `.vscode/` content is being committed here — only the ignore rule.