### PR TITLE
docs(CURRENT_STATE): record rune-ci self-guard merge (full guard coverage)

### DIFF
--- a/docs/context/CURRENT_STATE.md
+++ b/docs/context/CURRENT_STATE.md
@@ -61,7 +61,7 @@ Cross-repo epic [rune-docs#295](https://github.com/lpasquali/rune-docs/issues/29
 | rune | [rune#267](https://github.com/lpasquali/rune/pull/267) | [`42350b7`](https://github.com/lpasquali/rune/commit/42350b7) |
 | rune-audit | [rune-audit#102](https://github.com/lpasquali/rune-audit/pull/102) | [`c5ed779`](https://github.com/lpasquali/rune-audit/commit/c5ed779) |
 
-`rune-ci` self-wiring (dogfooding the guard on the guard's own repo, with `extra-exempt-paths` for its fixture directory) is a separate follow-up.
+`rune-ci` now dogfoods the guard too ([rune-ci#44](https://github.com/lpasquali/rune-ci/pull/44) merged), with `extra-exempt-paths` set to `actions/nginx-ingress-guard` and `tests/nginx-ingress-guard` (the fixture and test directories that intentionally contain the forbidden literals). `bash tests/nginx-ingress-guard/run.sh` also runs in rune-ci's integration suite. **All 8 RUNE repos** (rune, rune-operator, rune-ui, rune-charts, rune-docs, rune-airgapped, rune-audit, rune-ci) now have `RuneGate/Infra/NginxIngressGuard` enforced on every PR.
 
 ---
 


### PR DESCRIPTION
## Summary

One-line update to the 2026-04-18 entry: replace the "rune-ci self-wiring is a follow-up" note with the closed fact that rune-ci#44 now dogfoods the guard. All 8 RUNE repos enforce `RuneGate/Infra/NginxIngressGuard` on PRs.

Closes #316
Epic: rune-docs#295 (closed)

## DoD Level

- [x] **Level 3 — Documentation**

## Level 3 Checklist

- [x] `mkdocs build --strict` — will run on CI; single-line prose change.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| n/a | No triggers fired | Docs-only. |

## Acceptance Criteria Evidence

- [x] Single-line update in `docs/context/CURRENT_STATE.md` replacing the follow-up note with the closed state.

## Breaking Changes

None.

## Notes for Reviewer

Final persistence for the nginx-removal work. No further Cursor-owned items remain under epic #295.

Made with [Cursor](https://cursor.com)